### PR TITLE
Create hacs.json allowing for installation via HACS

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,6 @@
+{
+  "name": "XAPController"
+  "content_in_root": true,
+  "render_readme": true,
+  "iot_class": "Local Push"
+}

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-  "name": "XAPController"
+  "name": "XAPController",
   "content_in_root": true,
   "render_readme": true,
   "iot_class": "Local Push"


### PR DESCRIPTION
Many users use HACS (https://hacs.xyz/docs/publish/start) to make it easier to install custom components. By adding a hacs.json file, this project can be installed via HACS.