### PR TITLE
Fix the connection test: wrong class reference, and baud set too late

### DIFF
--- a/config_flow.py
+++ b/config_flow.py
@@ -59,7 +59,7 @@ def _build_xapconn(data):
     conn_type = data.get(CONF_CONNECTION_TYPE, "serial")
     xap_type = data.get(CONF_TYPE, "XAP800")
     if conn_type == "telnet":
-        xapconn = XAPX00.XAPX00(
+        xapconn = XAPX00(
             connection_type="telnet",
             telnet_host=data.get(CONF_HOST),
             telnet_port=data.get(CONF_PORT, 23),
@@ -68,11 +68,14 @@ def _build_xapconn(data):
             XAPType=xap_type,
         )
     else:
-        xapconn = XAPX00.XAPX00(
+        # baudRate must be a constructor argument, not assigned afterwards: the
+        # constructor opens the port, so a later assignment leaves the link running at
+        # the 38400 default and every exchange times out.
+        xapconn = XAPX00(
             data.get(CONF_PATH, "/dev/ttyUSB0"),
+            baudRate=data.get(CONF_BAUD, 38400),
             XAPType=xap_type,
         )
-        xapconn.baudRate = data.get(CONF_BAUD, 38400)
     return xapconn
 
 
@@ -125,6 +128,7 @@ class XapControllerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 if not connected:
                     errors["base"] = "cannot_connect"
             except Exception:
+                _LOGGER.exception("XAP connection test failed")
                 errors["base"] = "cannot_connect"
 
             if not errors or user_input.get("proceed_anyway"):
@@ -160,6 +164,7 @@ class XapControllerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     if not connected:
                         errors["base"] = "cannot_connect"
                 except Exception:
+                    _LOGGER.exception("XAP connection test failed")
                     errors["base"] = "cannot_connect"
             else:
                 self._connection_data = {**self._connection_data, **user_input}

--- a/media_player.py
+++ b/media_player.py
@@ -226,8 +226,12 @@ async def async_setup_entry(hass, entry, async_add_entities):
     else:
         conn_label = entry.data[CONF_PATH]
         def _make_conn():
-            conn = XAPX00(entry.data[CONF_PATH], XAPType=xap_type)
-            conn.baudRate  = entry.data.get(CONF_BAUD, 38400)
+            # baudRate belongs in the constructor — see _build_xapconn in config_flow.
+            conn = XAPX00(
+                entry.data[CONF_PATH],
+                baudRate=entry.data.get(CONF_BAUD, 38400),
+                XAPType=xap_type,
+            )
             conn.stereo    = stereo
             conn.convertDb = 1
             conn.conn_id   = entry.data[CONF_PATH]


### PR DESCRIPTION
Two independent faults, both of which make a serial setup fail in a way that looks like a wiring problem.

### `XAPX00.XAPX00(...)` is an `AttributeError`

`config_flow.py` does `from XAPX00 import XAPX00`, so the name is already the class. `_build_xapconn` then calls `XAPX00.XAPX00(...)`, which raises every time. The bare `except Exception` around both call sites catches it and reports `cannot_connect`, so **the connection test can never pass**, whatever hardware is attached.

I've also added `_LOGGER.exception(...)` to those two handlers — a swallowed traceback is exactly what hid this.

### `baudRate` is set after the port is already open

```python
xapconn = XAPX00(path, XAPType=xap_type)
xapconn.baudRate = data.get(CONF_BAUD, 38400)   # too late
```

`XAPX00.__init__` opens the serial port, so the link is already running at the 38400 default by the time the attribute is assigned. Any unit on a different rate times out on every exchange, which presents identically to a dead cable. It has to be a constructor argument.

`media_player.py` had the same pattern in `_make_conn` and is fixed the same way.

### Testing

Found and fixed against an XAP800 on a 57600 serial link, where the config flow could not be completed at all before this. Running with the fix since.

---

Part of a series from my fork ([defl/xap_controller](https://github.com/defl/xap_controller)) — these are the changes that look generally useful rather than specific to my install. Happy to split, squash or drop any of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)