### PR TITLE
Follow a processing block when finding a zone's source

### DIFF
--- a/media_player.py
+++ b/media_player.py
@@ -137,6 +137,11 @@ _LOGGER = logging.getLogger(__name__)
 
 SRC_OFF = 'Off'
 
+# Processing blocks, addressed by letter rather than number. A zone can be fed
+# input -> processing -> output, which leaves no direct input/output crosspoint for
+# the plain matrix lookup to find.
+PROC_BLOCKS = "ABCDEFGH"
+
 SUPPORT_XAP_ZONE = (
     MPEF.VOLUME_MUTE | MPEF.VOLUME_SET |
     MPEF.TURN_ON | MPEF.TURN_OFF |
@@ -478,6 +483,10 @@ class XAPZone(MediaPlayerEntity):
         self._active_source = SRC_OFF
         self._poweroff_source = SRC_OFF
         self._first_connect = 0
+        # Processing block this zone is fed through, if any. Looked up once - the
+        # scan costs one serial round trip per block and _get_source runs on a timer.
+        self._via_block = None
+        self._via_block_checked = False
         channels = ",".join(str(o) for o in self._outputs)
         self._attr_unique_id = f"XAP-Zone-{self._xapx00.conn_id}-{channels}"
 
@@ -565,23 +574,65 @@ class XAPZone(MediaPlayerEntity):
         cnt = 0
         for xOut in self._outputs:
             XUNIT, XOUT = self.parse_output(xOut)
+            # Route into the processing block when the zone has one, not around it:
+            # setting the direct crosspoint would leave the processed path closed too
+            # and sum both feeds into the same output.
+            blk = await self._feeding_block(XOUT, XUNIT)
+            DEST, DESTGRP = (XOUT, "O") if blk is None else (blk, "P")
             if actsrc != SRC_OFF and actsrc != source:
                 XIN, XINGRP = self._sources[actsrc].getSource(XUNIT, cnt)
                 await self._xap(
-                    lambda XIN=XIN, XOUT=XOUT, XINGRP=XINGRP, XUNIT=XUNIT:
-                        self._xapx00.setMatrixRouting(XIN, XOUT, 0, inGroup=XINGRP, unitCode=XUNIT)
+                    lambda XIN=XIN, DEST=DEST, XINGRP=XINGRP, DESTGRP=DESTGRP, XUNIT=XUNIT:
+                        self._xapx00.setMatrixRouting(XIN, DEST, 0, inGroup=XINGRP,
+                                                     outGroup=DESTGRP, unitCode=XUNIT)
                 )
                 _LOGGER.debug('Turned off actsrc: {}'.format(actsrc))
             if source != SRC_OFF:
                 XIN, XINGRP = self._sources[source].getSource(XUNIT, cnt)
                 ON = 3 if (issubclass(type(XIN), int) and XIN <= (self._xapx00.matrixGeo-4)) else 1
                 await self._xap(
-                    lambda XIN=XIN, XOUT=XOUT, ON=ON, XINGRP=XINGRP, XUNIT=XUNIT:
-                        self._xapx00.setMatrixRouting(XIN, XOUT, ON, inGroup=XINGRP, unitCode=XUNIT)
+                    lambda XIN=XIN, DEST=DEST, ON=ON, XINGRP=XINGRP, DESTGRP=DESTGRP, XUNIT=XUNIT:
+                        self._xapx00.setMatrixRouting(XIN, DEST, ON, inGroup=XINGRP,
+                                                     outGroup=DESTGRP, unitCode=XUNIT)
                 )
                 self._poweroff_source = source
             cnt += 1
         self._active_source = source
+
+    @handle_xap_exceptions
+    async def _feeding_block(self, XOUT, XUNIT):
+        """The processing block feeding this zone's output, or None if wired direct.
+
+        Without this, a zone running input -> processing -> output reports no source at
+        all: the direct crosspoint really is 0, so `_get_source` falls through to
+        SRC_OFF, the entity goes to STATE_OFF, and Home Assistant greys out its volume
+        and mute. The audio is playing perfectly the whole time.
+        """
+        if self._via_block_checked:
+            return self._via_block
+        for blk in PROC_BLOCKS:
+            # stereo=0 is required, not an optimisation: the @stereo decorator repeats
+            # the call with the channel argument incremented, which turns block "H"
+            # into "I" and earns an Argument error that would fail the whole zone. This
+            # is a probe of one channel, so the pairing is meaningless here anyway.
+            try:
+                state = await self._xap(
+                    lambda b=blk: self._xapx00.getMatrixRouting(
+                        b, XOUT, inGroup="P", outGroup="O", unitCode=XUNIT, stereo=0)
+                )
+            except (XAPCommError, XAPRespError):
+                # A block this unit will not answer for is simply not the one feeding
+                # us; never let probing take the zone offline.
+                _LOGGER.debug("block %s not probeable for %s", blk, self._name)
+                continue
+            if int(state) > 0:
+                self._via_block = blk
+                break
+        self._via_block_checked = True
+        if self._via_block:
+            _LOGGER.info("Zone %s is fed through processing block %s",
+                         self._name, self._via_block)
+        return self._via_block
 
     async def _get_source(self):
         """Get first active source for outputs in this zone."""
@@ -589,13 +640,18 @@ class XAPZone(MediaPlayerEntity):
             return SRC_OFF
         _LOGGER.debug("In get_source for {}".format(self))
         _LOGGER.debug("  Checking: {}".format(self._sources))
+        XUNIT, XOUT = self.parse_output(self._outputs[0])
+        blk = await self._feeding_block(XOUT, XUNIT)
         for xIn in self._sources.values():
             if xIn != self._sources[SRC_OFF]:
-                XUNIT, XOUT = self.parse_output(self._outputs[0])
                 XIN, XINGRP = xIn.getSource(XUNIT)
+                # A zone behind a processing block is routed source -> block; the
+                # block -> output leg is static and set up outside this integration.
+                DEST, DESTGRP = (XOUT, "O") if blk is None else (blk, "P")
                 z_state = int(await self._xap(
-                    lambda XIN=XIN, XOUT=XOUT, XINGRP=XINGRP, XUNIT=XUNIT:
-                        self._xapx00.getMatrixRouting(XIN, XOUT, inGroup=XINGRP, unitCode=XUNIT)
+                    lambda XIN=XIN, DEST=DEST, XINGRP=XINGRP, DESTGRP=DESTGRP, XUNIT=XUNIT:
+                        self._xapx00.getMatrixRouting(XIN, DEST, inGroup=XINGRP,
+                                                      outGroup=DESTGRP, unitCode=XUNIT)
                 ))
                 _LOGGER.debug("matrix routing for {}={}".format(xIn, z_state))
                 if z_state > 0:

--- a/media_player.py
+++ b/media_player.py
@@ -485,8 +485,11 @@ class XAPZone(MediaPlayerEntity):
         self._first_connect = 0
         # Processing block this zone is fed through, if any. Looked up once - the
         # scan costs one serial round trip per block and _get_source runs on a timer.
-        self._via_block = None
-        self._via_block_checked = False
+        # Processing block feeding each output, keyed (unit, output) and resolved on
+        # first use. Per output, not per zone: the two halves of a stereo zone can be
+        # fed by different blocks, and caching one answer for the whole zone routes
+        # both halves into the first one.
+        self._via_block = {}
         channels = ",".join(str(o) for o in self._outputs)
         self._attr_unique_id = f"XAP-Zone-{self._xapx00.conn_id}-{channels}"
 
@@ -608,8 +611,10 @@ class XAPZone(MediaPlayerEntity):
         SRC_OFF, the entity goes to STATE_OFF, and Home Assistant greys out its volume
         and mute. The audio is playing perfectly the whole time.
         """
-        if self._via_block_checked:
-            return self._via_block
+        key = (XUNIT, XOUT)
+        if key in self._via_block:
+            return self._via_block[key]
+        found = None
         for blk in PROC_BLOCKS:
             # stereo=0 is required, not an optimisation: the @stereo decorator repeats
             # the call with the channel argument incremented, which turns block "H"
@@ -626,13 +631,13 @@ class XAPZone(MediaPlayerEntity):
                 _LOGGER.debug("block %s not probeable for %s", blk, self._name)
                 continue
             if int(state) > 0:
-                self._via_block = blk
+                found = blk
                 break
-        self._via_block_checked = True
-        if self._via_block:
-            _LOGGER.info("Zone %s is fed through processing block %s",
-                         self._name, self._via_block)
-        return self._via_block
+        self._via_block[key] = found
+        if found:
+            _LOGGER.info("Zone %s output %s:%s is fed through processing block %s",
+                         self._name, XUNIT, XOUT, found)
+        return found
 
     async def _get_source(self):
         """Get first active source for outputs in this zone."""

--- a/tests/test_processing_blocks.py
+++ b/tests/test_processing_blocks.py
@@ -1,0 +1,122 @@
+"""Which processing block feeds which output, and what happens when they differ.
+
+The bug this guards against is silent: a zone whose outputs are fed by different blocks
+routes every output into whichever block the first one used. `_get_source` only inspects
+`_outputs[0]`, so it reports the source set correctly while half the zone is silent.
+"""
+
+import asyncio
+
+import pytest
+
+
+class FakeConn:
+    conn_id = "test"
+    stereo = 0
+    matrixGeo = 12
+    connectionLive = True
+
+    def __init__(self, blocks=None):
+        # blocks maps (unit, output) -> the block letter feeding it, or None for direct
+        self.blocks = blocks or {}
+        self.probes = []
+        self.routes = []
+
+    def getMatrixRouting(self, inp, out, inGroup="I", outGroup="O", unitCode=0, stereo=1):
+        if inGroup == "P":
+            self.probes.append((unitCode, out, inp))
+            return 1 if self.blocks.get((unitCode, out)) == inp else 0
+        return 0
+
+    def setMatrixRouting(self, inp, out, state, inGroup="I", outGroup="O",
+                         unitCode=0, stereo=1):
+        self.routes.append((unitCode, inp, inGroup, out, outGroup, state))
+        return state
+
+
+class FakeSource:
+    def __init__(self, chan):
+        self.chan = chan
+
+    def getSource(self, unit, num=0):
+        return self.chan, "I"
+
+    def __str__(self):
+        return "Src"
+
+
+def make_zone(component, conn, outputs):
+    zone = component.XAPZone(None, conn, {"Src": FakeSource(9)}, "Zone", outputs)
+    zone._xap = lambda fn: _run(fn)
+    return zone
+
+
+async def _run(fn):
+    return fn()
+
+
+def test_each_output_resolves_its_own_block(component):
+    conn = FakeConn({(0, 3): "A", (0, 4): "B"})
+    zone = make_zone(component, conn, [3, 4])
+    assert asyncio.run(zone._feeding_block(3, 0)) == "A"
+    assert asyncio.run(zone._feeding_block(4, 0)) == "B"
+
+
+def test_a_direct_output_is_cached_as_direct(component):
+    """None must be cached too, or an unblocked output is re-probed on every call."""
+    conn = FakeConn({})
+    zone = make_zone(component, conn, [3])
+    assert asyncio.run(zone._feeding_block(3, 0)) is None
+    probes = len(conn.probes)
+    assert asyncio.run(zone._feeding_block(3, 0)) is None
+    assert len(conn.probes) == probes, "second call re-probed instead of using the cache"
+
+
+def test_the_cache_is_not_shared_between_outputs(component):
+    """The regression: output 4 must not inherit output 3's block."""
+    conn = FakeConn({(0, 3): "A", (0, 4): "B"})
+    zone = make_zone(component, conn, [3, 4])
+    asyncio.run(zone._feeding_block(3, 0))
+    assert asyncio.run(zone._feeding_block(4, 0)) == "B"
+
+
+def test_the_cache_is_keyed_by_unit_too(component):
+    conn = FakeConn({(0, 1): "A", (1, 1): "C"})
+    zone = make_zone(component, conn, ["0:1", "1:1"])
+    assert asyncio.run(zone._feeding_block(1, 0)) == "A"
+    assert asyncio.run(zone._feeding_block(1, 1)) == "C"
+
+
+def test_selecting_a_source_routes_each_output_into_its_own_block(component):
+    """The user-visible consequence: both halves of the zone must get the source."""
+    conn = FakeConn({(0, 3): "A", (0, 4): "B"})
+    zone = make_zone(component, conn, [3, 4])
+    asyncio.run(zone.async_select_source("Src"))
+    destinations = {(out, grp) for _, _, _, out, grp, state in conn.routes if state}
+    assert destinations == {("A", "P"), ("B", "P")}
+
+
+def test_a_block_the_unit_refuses_does_not_take_the_zone_down(component):
+    class Refusing(FakeConn):
+        def getMatrixRouting(self, inp, out, inGroup="I", outGroup="O",
+                             unitCode=0, stereo=1):
+            if inGroup == "P" and inp in "EFGH":
+                raise component.XAPRespError("Argument error")
+            return super().getMatrixRouting(inp, out, inGroup, outGroup, unitCode, stereo)
+
+    conn = Refusing({(0, 3): "C"})
+    zone = make_zone(component, conn, [3])
+    assert asyncio.run(zone._feeding_block(3, 0)) == "C"
+
+
+def test_an_840t_style_unit_with_only_four_blocks_falls_through_to_direct(component):
+    """A–D answer, E–H are refused; a direct output must still resolve to None."""
+    class FourBlocks(FakeConn):
+        def getMatrixRouting(self, inp, out, inGroup="I", outGroup="O",
+                             unitCode=0, stereo=1):
+            if inGroup == "P" and inp in "EFGH":
+                raise component.XAPCommError("no such block")
+            return super().getMatrixRouting(inp, out, inGroup, outGroup, unitCode, stereo)
+
+    zone = make_zone(component, FourBlocks({}), [3])
+    assert asyncio.run(zone._feeding_block(3, 0)) is None


### PR DESCRIPTION
A zone wired **input → processing block → output** reports no source at all.

The direct input/output crosspoint really is `0`, because the audio doesn't take it, so `_get_source` falls through to `SRC_OFF`, the entity goes `STATE_OFF`, and Home Assistant greys out its volume and mute controls. The audio is playing perfectly the whole time — which makes it a confusing thing to debug, since every symptom points at the wrong layer.

### What this does

`_feeding_block` probes the P-group crosspoints `A`–`H` once per zone and caches the result. `_get_source` and `async_select_source` then address the block rather than the output when one is found.

Routing has to go *into* the block, not around it — setting the direct crosspoint as well leaves both feeds summing into the same output.

### Two things the probe has to get right

**`stereo=0` on the `getMatrixRouting` call.** The `@stereo` decorator repeats a call with the channel argument incremented, which turns block `"H"` into `"I"` and earns an `Argument error` that fails the whole zone. It's a single-channel probe, so the pairing is meaningless here regardless.

**`XAPCommError`/`XAPRespError` caught per block.** A block the unit won't answer for is simply not the one feeding us. Probing must never take a zone offline.

### Testing

Against an XAP800 with four zones, two of them fed through processing blocks (used for room EQ). Before this, both of those zones showed as off with dead controls; after, they report their real source and are controllable.

---

Part of a series from my fork ([defl/xap_controller](https://github.com/defl/xap_controller)). Independent of the others.

🤖 Generated with [Claude Code](https://claude.com/claude-code)