### PR TITLE
Add a unit test suite, and fix the parse_output crash it found

### DIFF
--- a/media_player.py
+++ b/media_player.py
@@ -533,6 +533,11 @@ class XAPZone(MediaPlayerEntity):
             if ":" in output:
                 XUNIT, XOUT =  output.split(":")
             elif output.isdigit():
+                # Unit 0, same as the bare int form. Without this XUNIT is never bound
+                # and the return below raises UnboundLocalError - and a bare numeric
+                # string is a shape _validate_sources_zones accepts and the README's own
+                # examples mix in, so `{"Kitchen": ["3"]}` crashed setup.
+                XUNIT = 0
                 XOUT = int(output)
             else:
                 raise Exception('Invalid Output String')

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,144 @@
+"""Make the component importable without Home Assistant installed.
+
+`pytest-homeassistant-custom-component` pulls in the whole of Home Assistant to test what
+is, here, a few hundred lines of gain arithmetic and config parsing. These stubs cover the
+handful of names the module touches at import time, so the suite runs anywhere with just
+pytest — including on a machine that has never had HA on it.
+
+The stubs are deliberately dumb. Anything that needs real Home Assistant behaviour does not
+belong in this suite.
+"""
+
+import sys
+import types
+
+import pytest
+
+
+def _module(name):
+    mod = types.ModuleType(name)
+    sys.modules[name] = mod
+    return mod
+
+
+def _install_stubs():
+    if "homeassistant" in sys.modules:
+        return
+
+    _module("homeassistant")
+
+    ce = _module("homeassistant.config_entries")
+    ce.SOURCE_IMPORT = "import"
+
+    class _Flow:
+        def __init_subclass__(cls, **kwargs):  # domain=... on the subclass
+            pass
+
+    ce.ConfigFlow = _Flow
+    ce.OptionsFlow = type("OptionsFlow", (), {})
+    ce.ConfigEntry = type("ConfigEntry", (), {})
+
+    const = _module("homeassistant.const")
+    const.STATE_OFF = "off"
+    const.STATE_ON = "on"
+    const.CONF_NAME = "name"
+    const.Platform = types.SimpleNamespace(MEDIA_PLAYER="media_player")
+
+    core = _module("homeassistant.core")
+    core.HomeAssistant = type("HomeAssistant", (), {})
+    core.SupportsResponse = types.SimpleNamespace(OPTIONAL="optional")
+    core.callback = lambda fn: fn
+
+    exc = _module("homeassistant.exceptions")
+
+    class HomeAssistantError(Exception):
+        pass
+
+    class ServiceValidationError(HomeAssistantError):
+        pass
+
+    exc.HomeAssistantError = HomeAssistantError
+    exc.ServiceValidationError = ServiceValidationError
+
+    helpers = _module("homeassistant.helpers")
+    cv = _module("homeassistant.helpers.config_validation")
+    cv.string = str
+    helpers.config_validation = cv
+
+    comp = _module("homeassistant.components")
+    mp = _module("homeassistant.components.media_player")
+    mp.MediaPlayerEntity = type("MediaPlayerEntity", (), {})
+    mp.MediaType = types.SimpleNamespace(MUSIC="music")
+    comp.media_player = mp
+
+    mp_const = _module("homeassistant.components.media_player.const")
+
+    class _Feature(int):
+        """Enough of an IntFlag for `A | B` in the SUPPORT_ constants."""
+
+        def __or__(self, other):
+            return _Feature(int(self) | int(other))
+
+    mp_const.MediaPlayerEntityFeature = types.SimpleNamespace(
+        VOLUME_MUTE=_Feature(8), VOLUME_SET=_Feature(4),
+        TURN_ON=_Feature(128), TURN_OFF=_Feature(256),
+        SELECT_SOURCE=_Feature(2048),
+    )
+    mp.const = mp_const
+
+    # voluptuous: only Invalid and the schema-building names used at import time.
+    vol = _module("voluptuous")
+
+    class Invalid(Exception):
+        pass
+
+    vol.Invalid = Invalid
+    vol.Schema = lambda *a, **k: types.SimpleNamespace(schema=a[0] if a else None)
+    vol.Required = lambda *a, **k: a[0] if a else None
+    vol.Optional = lambda *a, **k: a[0] if a else None
+    vol.In = lambda *a, **k: a[0] if a else None
+    vol.All = lambda *a, **k: a[0] if a else None
+    vol.Coerce = lambda *a, **k: a[0] if a else None
+    vol.Range = lambda *a, **k: None
+
+    # XAPX00: the entities only ever reach it through the connection object, which every
+    # test supplies itself. Nothing here is exercised.
+    xap = _module("XAPX00")
+    xap.__version__ = "stub"
+    xap.XAPX00 = type("XAPX00", (), {})
+
+    class XAPCommError(Exception):
+        pass
+
+    class XAPRespError(Exception):
+        pass
+
+    xap.XAPCommError = XAPCommError
+    xap.XAPRespError = XAPRespError
+
+
+_install_stubs()
+
+# The component is a flat package at the repo root (hacs.json content_in_root), so the
+# root has to be importable and `.config_flow` has to resolve as a relative import.
+_ROOT = __import__("pathlib").Path(__file__).resolve().parent.parent
+if str(_ROOT.parent) not in sys.path:
+    sys.path.insert(0, str(_ROOT.parent))
+
+_PKG = _ROOT.name
+
+
+@pytest.fixture(scope="session")
+def component():
+    import importlib
+
+    pkg = importlib.import_module(_PKG)
+    return importlib.import_module(f"{_PKG}.media_player")
+
+
+@pytest.fixture(scope="session")
+def config_flow():
+    import importlib
+
+    importlib.import_module(_PKG)
+    return importlib.import_module(f"{_PKG}.config_flow")

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1,0 +1,87 @@
+"""Channel-spec parsing, and the config-flow validation in front of it.
+
+These two have to agree: config_flow decides what the user may save, parse_output and
+parse_source decide what the component can actually do with it. A spec the first accepts
+and the second cannot parse is a crash at setup, long after the mistake was made.
+"""
+
+import json
+
+import pytest
+
+
+def make_zone(component, outputs):
+    return component.XAPZone(None, _Conn(), {}, "Zone", outputs)
+
+
+def make_source(component, inputs):
+    return component.XAPSource(None, _Conn(), "Src", inputs)
+
+
+class _Conn:
+    conn_id = "test"
+    stereo = 0
+
+
+@pytest.mark.parametrize(
+    "spec,expected",
+    [
+        (3, (0, 3)),
+        ("2:1", (2, 1)),
+        ("0:8", (0, 8)),
+    ],
+)
+def test_parse_output_accepts_documented_forms(component, spec, expected):
+    assert make_zone(component, [spec]).parse_output(spec) == expected
+
+
+def test_parse_output_accepts_a_bare_numeric_string(component):
+    """`{"Kitchen": ["3"]}` passes config-flow validation, so it must parse.
+
+    _validate_sources_zones accepts `(int, str)` for every channel entry, and the README's
+    own examples mix the two. A string that is just digits and carries no unit therefore
+    reaches parse_output, and has to mean unit 0 exactly as the integer 3 does.
+    """
+    assert make_zone(component, ["3"]).parse_output("3") == (0, 3)
+
+
+def test_parse_output_rejects_nonsense(component):
+    with pytest.raises(Exception):
+        make_zone(component, [1]).parse_output("kitchen")
+
+
+@pytest.mark.parametrize(
+    "spec,chan,unit,bus,busgrp",
+    [
+        (9, 9, 0, None, "E"),
+        ("1:9", 9, 1, None, "E"),
+        ("1:9:O", 9, 1, "O", "E"),
+        ("1:9:O:E", 9, 1, "O", "E"),
+        ("11", 11, 0, None, "E"),
+    ],
+)
+def test_parse_source_accepts_documented_forms(component, spec, chan, unit, bus, busgrp):
+    src = make_source(component, [spec])
+    got = src._inputs[0]
+    assert (got["CHAN"], got["UNIT"], got["BUS"], got["BUSGRP"]) == (chan, unit, bus, busgrp)
+
+
+def test_source_channel_count_follows_the_spec_list(component):
+    assert make_source(component, [9, 10]).numChannels == 2
+
+
+# --- config flow validation -------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "raw", ['{"Kitchen": [3]}', '{"Kitchen": ["2:1", "2:2"]}', '{"A": [1], "B": [2]}', "{}"]
+)
+def test_valid_sources_zones_accepted(config_flow, raw):
+    config_flow._validate_sources_zones(raw, "zones")
+
+
+@pytest.mark.parametrize(
+    "raw", ['{"Kitchen": 3}', '["Kitchen"]', '{"Kitchen": [1.5]}', "{not json"]
+)
+def test_invalid_sources_zones_rejected(config_flow, raw):
+    with pytest.raises(Exception):
+        config_flow._validate_sources_zones(raw, "zones")


### PR DESCRIPTION
### The bug

`parse_output` raises `UnboundLocalError` for a bare numeric string:

```python
elif output.isdigit():
    XOUT = int(output)      # XUNIT never assigned
...
return int(XUNIT), int(XOUT)   # UnboundLocalError
```

That shape is reachable from a normal config. `_validate_sources_zones` accepts `(int, str)` for every channel entry, and the README's own examples mix the two forms, so `{"Kitchen": ["3"]}` passes validation and then crashes setup. It now means unit 0, exactly as the integer `3` does.

### The suite

There were no tests, so I added the ones that would have caught it — covering the channel-spec parsers and the config-flow validation that decides what reaches them.

**It needs nothing but `pytest`.** `tests/conftest.py` stubs the handful of `homeassistant`, `voluptuous` and `XAPX00` names the module touches at import time, rather than pulling in `pytest-homeassistant-custom-component` and all of Home Assistant to exercise a few hundred lines of parsing and arithmetic. The stubs are deliberately dumb — anything needing real HA behaviour doesn't belong in this suite.

```
$ python -m pytest tests -q
19 passed
```

Happy to drop the stub approach for `pytest-homeassistant-custom-component` if you'd rather have the heavier, more faithful harness — I went this way so the suite runs on a machine that has never had HA installed, but it's your call which you'd maintain.

---

Part of a series from my fork ([defl/xap_controller](https://github.com/defl/xap_controller)). Independent of the others, though a couple of them add tests on top of this `conftest.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)