### PR TITLE
Ignore the __pycache__ directory rather than two filenames

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
-
-__pycache__/__init__.cpython-314.pyc
-__pycache__/media_player.cpython-314.pyc
-
+__pycache__/
+*.py[cod]


### PR DESCRIPTION
`.gitignore` currently lists two exact filenames:

```
__pycache__/__init__.cpython-314.pyc
__pycache__/media_player.cpython-314.pyc
```

That only covers those two names on that one Python version. A different interpreter writes `cpython-313`/`cpython-312`, and `config_flow.py` has no entry at all — so bytecode slips into a commit as soon as anyone runs a different Python than the one those lines were written against.

That isn't hypothetical: it's how **my fork ended up committing three `cpython-313.pyc` files**, which then dirtied the tree on every compile and shipped stale bytecode to every HACS install until I noticed. This repo is clean today (nothing under `__pycache__` is tracked) — this just closes the door.

```
__pycache__/
*.py[cod]
```

No tracked files are affected.

---

Part of a series from my fork ([defl/xap_controller](https://github.com/defl/xap_controller)). The smallest one; independent of the others.

🤖 Generated with [Claude Code](https://claude.com/claude-code)