### PR TITLE
Add xap_controller.send_command for raw command access

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,3 +97,28 @@ media_player:
 
 Setup Notes:
 For the sources, set the gain levels in the Clearone Console app.  They are very sensitive and should be calibrated to 0db.  I have removed the ability to change the source gain levels from the UI to prevent mis-configuation.  It can be added back through the source gode by adding MPEF.VOLUME_SET to the SOURCE capability list (if you need it, for example if you don't have the Console app available).
+
+## Raw command access (`xap_controller.send_command`)
+
+For hands-on work on the unit â€” reading `LABEL`, `MTRX`, `MAX`, or trying anything the
+entities do not model â€” call the service rather than opening the serial port from another
+process. `XAPCommand` owns the device address, the terminator, the response parsing and
+the lock, so going through it cannot collide with the entities mid-frame.
+
+```yaml
+action: xap_controller.send_command
+data:
+  command: GAIN 7 O
+response_variable: reply
+```
+
+Returns `{"command": "GAIN 7 O", "response": ["GAIN 7 O -33.00 A", ...]}`. Pass only the
+command body; the `#5<unit>` prefix and the `\r` terminator are added for you.
+
+- `unit` (default 0) addresses other XAPs on the expansion chain.
+- `return_count` (default 16) is how many trailing tokens of the reply to keep. It is a
+  tail, not a limit, so too small a value silently drops the front of the answer â€” at 2,
+  `LABEL 5 O` comes back as `- Patio` with the `3L` missing. The default is past the
+  longest reply seen; asking for more tokens than arrive just returns what arrived.
+- A command the unit refuses comes back as `{"command": ..., "error": ...}` rather than
+  raising, because a rejection is a normal result when probing an unfamiliar unit.

--- a/__init__.py
+++ b/__init__.py
@@ -37,4 +37,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    from .media_player import async_release_connection
+
+    unloaded = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unloaded:
+        async_release_connection(hass, entry)
+    return unloaded

--- a/media_player.py
+++ b/media_player.py
@@ -119,11 +119,15 @@ import functools
 import json
 import threading
 
+import voluptuous as vol
+
 from homeassistant.components.media_player import MediaPlayerEntity
 import homeassistant.components.media_player as MP
 from homeassistant.components.media_player.const import MediaPlayerEntityFeature as MPEF
 from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.core import SupportsResponse
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+import homeassistant.helpers.config_validation as cv
 from XAPX00 import __version__ as XAPVER, XAPX00, XAPCommError, XAPRespError
 
 from .config_flow import (
@@ -191,6 +195,75 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     )
 
 
+SERVICE_SEND_COMMAND = "send_command"
+
+SEND_COMMAND_SCHEMA = vol.Schema(
+    {
+        vol.Required("command"): cv.string,
+        vol.Optional("unit", default=0): vol.All(vol.Coerce(int), vol.Range(min=0, max=7)),
+        # `rtnCount` is "keep the last N whitespace-separated tokens of the reply", so a
+        # small value silently truncates: at 2, `LABEL 5 O` returns ["-", "Patio"] and
+        # loses the "3L". 16 is past the longest reply seen, and asking for more tokens
+        # than arrive simply returns what arrived â€” so the default shows the whole line.
+        vol.Optional("return_count", default=16): vol.All(
+            vol.Coerce(int), vol.Range(min=0, max=64)
+        ),
+    }
+)
+
+
+def _register_send_command(hass, xapconn):
+    """Expose a raw command channel: `xap_controller.send_command`.
+
+    The point is hands-on work on the unit â€” reading LABEL/MTRX/MAX, trying settings the
+    entities do not model â€” without a second process opening the serial port behind this
+    integration's back. XAPCommand already owns the framing, the device address, the
+    response parsing and the lock, so going through it is both safer and less code than a
+    side channel.
+
+    Registered against the first config entry to set up; the `unit` field addresses other
+    XAPs on the expansion chain, which is the multi-unit case that actually exists.
+    """
+    if hass.services.has_service(DOMAIN, SERVICE_SEND_COMMAND):
+        return
+
+    async def _handle(call):
+        raw = call.data["command"].strip()
+        if not raw:
+            raise ServiceValidationError("command is empty")
+        parts = raw.split()
+        verb, args = parts[0], parts[1:]
+
+        def _run():
+            with xapconn._lock:
+                return xapconn.XAPCommand(
+                    verb, *args,
+                    unitCode=call.data["unit"],
+                    rtnCount=call.data["return_count"],
+                )
+
+        try:
+            result = await hass.async_add_executor_job(_run)
+        except (XAPCommError, XAPRespError) as err:
+            # A refused command is a normal outcome when probing an unfamiliar unit â€”
+            # report it as the answer rather than as an integration failure.
+            return {"command": raw, "error": str(err) or err.__class__.__name__}
+        if isinstance(result, (list, tuple)):
+            result = [str(x) for x in result]
+        else:
+            result = str(result)
+        return {"command": raw, "response": result}
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SEND_COMMAND,
+        _handle,
+        schema=SEND_COMMAND_SCHEMA,
+        supports_response=SupportsResponse.OPTIONAL,
+    )
+    _LOGGER.info("Registered %s.%s", DOMAIN, SERVICE_SEND_COMMAND)
+
+
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up XAP Controller media player entities from a config entry."""
     sources = json.loads(entry.data[CONF_SOURCES])
@@ -244,6 +317,8 @@ async def async_setup_entry(hass, entry, async_add_entities):
     connected = await hass.async_add_executor_job(xapconn.test_connection)
     if not connected:
         _LOGGER.warning('Not connected to %s', conn_label)
+
+    _register_send_command(hass, xapconn)
 
     source_objs = []
     zonesources = {}

--- a/media_player.py
+++ b/media_player.py
@@ -117,6 +117,7 @@ media_player:
 import logging
 import functools
 import json
+import shlex
 import threading
 
 import voluptuous as vol
@@ -208,21 +209,51 @@ SEND_COMMAND_SCHEMA = vol.Schema(
         vol.Optional("return_count", default=16): vol.All(
             vol.Coerce(int), vol.Range(min=0, max=64)
         ),
+        # Only needed with more than one XAP system configured as separate entries;
+        # with one entry the connection is unambiguous and this can be omitted.
+        vol.Optional("entry_id"): cv.string,
     }
 )
 
 
-def _register_send_command(hass, xapconn):
+def _connection_for(hass, entry_id=None):
+    """The XAPX00 connection a service call should use.
+
+    Resolved per call rather than captured at registration, so the service cannot end up
+    bound to a connection whose config entry has since been unloaded.
+    """
+    conns = hass.data.get(DOMAIN, {})
+    if not conns:
+        raise ServiceValidationError("No XAP connection is currently set up")
+    if entry_id is not None:
+        if entry_id not in conns:
+            raise ServiceValidationError(
+                f"No set-up XAP config entry with id {entry_id}; "
+                f"known ids: {', '.join(sorted(conns))}"
+            )
+        return conns[entry_id]
+    if len(conns) > 1:
+        # Guessing here would silently talk to whichever entry set up first. A chained
+        # system is one entry and reaches its other units via the `unit` field; several
+        # entries means several independent systems, and only the caller knows which.
+        raise ServiceValidationError(
+            "More than one XAP config entry is set up; pass entry_id. "
+            f"Known ids: {', '.join(sorted(conns))}"
+        )
+    return next(iter(conns.values()))
+
+
+def _register_send_command(hass):
     """Expose a raw command channel: `xap_controller.send_command`.
 
-    The point is hands-on work on the unit â€” reading LABEL/MTRX/MAX, trying settings the
-    entities do not model â€” without a second process opening the serial port behind this
+    The point is hands-on work on the unit — reading LABEL/MTRX/MAX, trying settings the
+    entities do not model — without a second process opening the serial port behind this
     integration's back. XAPCommand already owns the framing, the device address, the
     response parsing and the lock, so going through it is both safer and less code than a
     side channel.
 
-    Registered against the first config entry to set up; the `unit` field addresses other
-    XAPs on the expansion chain, which is the multi-unit case that actually exists.
+    The service is registered once and looks its connection up at call time; see
+    `async_release_connection` for the teardown side.
     """
     if hass.services.has_service(DOMAIN, SERVICE_SEND_COMMAND):
         return
@@ -231,8 +262,17 @@ def _register_send_command(hass, xapconn):
         raw = call.data["command"].strip()
         if not raw:
             raise ServiceValidationError("command is empty")
-        parts = raw.split()
+        try:
+            # shlex rather than str.split so a quoted argument survives: a label is a
+            # command argument that legitimately contains spaces, and
+            # `LABEL 5 O "Living Room"` is otherwise five tokens rather than three.
+            parts = shlex.split(raw)
+        except ValueError as err:
+            raise ServiceValidationError(f"could not parse command: {err}") from err
+        if not parts:
+            raise ServiceValidationError("command is empty")
         verb, args = parts[0], parts[1:]
+        xapconn = _connection_for(hass, call.data.get("entry_id"))
 
         def _run():
             with xapconn._lock:
@@ -245,7 +285,7 @@ def _register_send_command(hass, xapconn):
         try:
             result = await hass.async_add_executor_job(_run)
         except (XAPCommError, XAPRespError) as err:
-            # A refused command is a normal outcome when probing an unfamiliar unit â€”
+            # A refused command is a normal outcome when probing an unfamiliar unit —
             # report it as the answer rather than as an integration failure.
             return {"command": raw, "error": str(err) or err.__class__.__name__}
         if isinstance(result, (list, tuple)):
@@ -262,6 +302,21 @@ def _register_send_command(hass, xapconn):
         supports_response=SupportsResponse.OPTIONAL,
     )
     _LOGGER.info("Registered %s.%s", DOMAIN, SERVICE_SEND_COMMAND)
+
+
+def async_release_connection(hass, entry):
+    """Drop an unloaded entry's connection, and the service with the last one.
+
+    Without this the service outlives its connection: reloading or deleting the entry
+    left `send_command` registered against a dead XAPX00, and the has_service guard meant
+    no surviving entry could take it over, so it stayed broken until a full restart.
+    """
+    conns = hass.data.get(DOMAIN, {})
+    conns.pop(entry.entry_id, None)
+    if not conns and hass.services.has_service(DOMAIN, SERVICE_SEND_COMMAND):
+        hass.services.async_remove(DOMAIN, SERVICE_SEND_COMMAND)
+        _LOGGER.info("Removed %s.%s with the last config entry",
+                     DOMAIN, SERVICE_SEND_COMMAND)
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
@@ -318,7 +373,8 @@ async def async_setup_entry(hass, entry, async_add_entities):
     if not connected:
         _LOGGER.warning('Not connected to %s', conn_label)
 
-    _register_send_command(hass, xapconn)
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = xapconn
+    _register_send_command(hass)
 
     source_objs = []
     zonesources = {}

--- a/services.yaml
+++ b/services.yaml
@@ -10,6 +10,7 @@ send_command:
       description: >-
         The command body only — the device address and terminator are added for you.
         Examples: "VER", "GAIN 7 O", "LABEL 7 O", "MTRX 9 I 7 O", "MAX 7 O".
+        An argument containing spaces must be quoted: LABEL 5 O "Living Room".
       required: true
       example: GAIN 7 O
       selector:
@@ -37,3 +38,12 @@ send_command:
           min: 0
           max: 64
           mode: box
+    entry_id:
+      name: Config entry
+      description: >-
+        Which XAP system to talk to, when more than one is configured as a separate
+        config entry. Leave empty with a single entry. Chained units are one entry —
+        use the Unit field for those, not this.
+      required: false
+      selector:
+        text:

--- a/services.yaml
+++ b/services.yaml
@@ -1,0 +1,39 @@
+send_command:
+  name: Send raw command
+  description: >-
+    Send a raw ClearOne command to the XAP and return its reply. Goes through the
+    integration's own connection and lock, so it cannot collide with the entities the way
+    a second process opening the serial port would.
+  fields:
+    command:
+      name: Command
+      description: >-
+        The command body only — the device address and terminator are added for you.
+        Examples: "VER", "GAIN 7 O", "LABEL 7 O", "MTRX 9 I 7 O", "MAX 7 O".
+      required: true
+      example: GAIN 7 O
+      selector:
+        text:
+    unit:
+      name: Unit
+      description: XAP unit code on the expansion chain. 0 unless you have more than one.
+      required: false
+      default: 0
+      selector:
+        number:
+          min: 0
+          max: 7
+          mode: box
+    return_count:
+      name: Return elements
+      description: >-
+        How many trailing tokens of the reply to keep. The default of 16 is past the
+        longest reply seen, so you get the whole line; lower it only if you want just the
+        value. At 2, "LABEL 5 O" returns just "- Patio" and drops the "3L".
+      required: false
+      default: 16
+      selector:
+        number:
+          min: 0
+          max: 64
+          mode: box

--- a/tests/test_send_command.py
+++ b/tests/test_send_command.py
@@ -1,0 +1,175 @@
+"""Registration, teardown and argument parsing for xap_controller.send_command."""
+
+import asyncio
+
+import pytest
+
+
+class FakeServices:
+    def __init__(self):
+        self.registered = {}
+
+    def has_service(self, domain, service):
+        return (domain, service) in self.registered
+
+    def async_register(self, domain, service, handler, schema=None, supports_response=None):
+        self.registered[(domain, service)] = handler
+
+    def async_remove(self, domain, service):
+        self.registered.pop((domain, service), None)
+
+
+class FakeHass:
+    def __init__(self):
+        self.data = {}
+        self.services = FakeServices()
+
+    async def async_add_executor_job(self, fn):
+        return fn()
+
+
+class FakeEntry:
+    def __init__(self, entry_id):
+        self.entry_id = entry_id
+
+
+class FakeConn:
+    def __init__(self, name="a", reply="OK"):
+        self.name = name
+        self.reply = reply
+        self.calls = []
+
+        class _Lock:
+            def __enter__(self_inner):
+                return None
+
+            def __exit__(self_inner, *a):
+                return False
+
+        self._lock = _Lock()
+
+    def XAPCommand(self, verb, *args, unitCode=0, rtnCount=2):
+        self.calls.append((verb, args, unitCode, rtnCount))
+        if isinstance(self.reply, Exception):
+            raise self.reply
+        return self.reply
+
+
+class Call:
+    def __init__(self, **data):
+        data.setdefault("unit", 0)
+        data.setdefault("return_count", 16)
+        self.data = data
+
+
+def setup(component, conns):
+    hass = FakeHass()
+    for entry_id, conn in conns.items():
+        hass.data.setdefault(component.DOMAIN, {})[entry_id] = conn
+    component._register_send_command(hass)
+    handler = hass.services.registered[(component.DOMAIN, component.SERVICE_SEND_COMMAND)]
+    return hass, handler
+
+
+# --- connection resolution ---------------------------------------------------------
+
+def hass_with(component, conns):
+    hass = FakeHass()
+    hass.data[component.DOMAIN] = dict(conns)
+    return hass
+
+
+def test_a_single_entry_needs_no_entry_id(component):
+    conn = FakeConn()
+    assert component._connection_for(hass_with(component, {"e1": conn})) is conn
+
+
+def test_entry_id_selects_among_several(component):
+    a, b = FakeConn("a"), FakeConn("b")
+    hass = hass_with(component, {"e1": a, "e2": b})
+    assert component._connection_for(hass, "e2") is b
+
+
+def test_several_entries_without_entry_id_is_refused_not_guessed(component):
+    """Guessing would silently talk to whichever entry set up first."""
+    hass = hass_with(component, {"e1": FakeConn("a"), "e2": FakeConn("b")})
+    with pytest.raises(Exception) as err:
+        component._connection_for(hass)
+    assert "entry_id" in str(err.value)
+
+
+def test_an_unknown_entry_id_is_refused(component):
+    hass = hass_with(component, {"e1": FakeConn()})
+    with pytest.raises(Exception):
+        component._connection_for(hass, "nope")
+
+
+def test_no_connection_at_all_is_refused(component):
+    with pytest.raises(Exception):
+        component._connection_for(hass_with(component, {}))
+
+
+# --- teardown ----------------------------------------------------------------------
+
+def test_the_service_goes_away_with_the_last_entry(component):
+    hass, _ = setup(component, {"e1": FakeConn()})
+    component.async_release_connection(hass, FakeEntry("e1"))
+    assert not hass.services.has_service(component.DOMAIN, component.SERVICE_SEND_COMMAND)
+
+
+def test_the_service_survives_while_another_entry_is_up(component):
+    hass, _ = setup(component, {"e1": FakeConn("a"), "e2": FakeConn("b")})
+    component.async_release_connection(hass, FakeEntry("e1"))
+    assert hass.services.has_service(component.DOMAIN, component.SERVICE_SEND_COMMAND)
+    assert list(hass.data[component.DOMAIN]) == ["e2"]
+
+
+def test_a_reloaded_entry_does_not_leave_a_dead_connection_behind(component):
+    """The reported bug: unload then set up again must reach the new connection."""
+    old, new = FakeConn("old"), FakeConn("new")
+    hass, _ = setup(component, {"e1": old})
+    component.async_release_connection(hass, FakeEntry("e1"))
+    hass.data.setdefault(component.DOMAIN, {})["e1"] = new
+    component._register_send_command(hass)
+    handler = hass.services.registered[(component.DOMAIN, component.SERVICE_SEND_COMMAND)]
+    asyncio.run(handler(Call(command="VER")))
+    assert new.calls and not old.calls
+
+
+# --- argument parsing --------------------------------------------------------------
+
+def test_a_quoted_argument_stays_one_token(component):
+    conn = FakeConn()
+    _, handler = setup(component, {"e1": conn})
+    asyncio.run(handler(Call(command='LABEL 5 O "Living Room"')))
+    verb, args, _, _ = conn.calls[0]
+    assert (verb, args) == ("LABEL", ("5", "O", "Living Room"))
+
+
+def test_plain_arguments_are_unchanged(component):
+    conn = FakeConn()
+    _, handler = setup(component, {"e1": conn})
+    asyncio.run(handler(Call(command="GAIN 7 O")))
+    assert conn.calls[0][:2] == ("GAIN", ("7", "O"))
+
+
+def test_an_unbalanced_quote_is_a_validation_error_not_a_traceback(component):
+    _, handler = setup(component, {"e1": FakeConn()})
+    with pytest.raises(Exception):
+        asyncio.run(handler(Call(command='LABEL 5 O "Living')))
+
+
+@pytest.mark.parametrize("raw", ["", "   "])
+def test_an_empty_command_is_refused(component, raw):
+    _, handler = setup(component, {"e1": FakeConn()})
+    with pytest.raises(Exception):
+        asyncio.run(handler(Call(command=raw)))
+
+
+def test_a_refused_command_comes_back_as_data(component):
+    from XAPX00 import XAPRespError
+
+    conn = FakeConn(reply=XAPRespError("Argument error"))
+    _, handler = setup(component, {"e1": conn})
+    out = asyncio.run(handler(Call(command="BOGUS 1")))
+    assert "error" in out and "response" not in out


### PR DESCRIPTION
Adds a service that sends a raw ClearOne command through the integration's own connection and returns the reply.

```yaml
action: xap_controller.send_command
data:
  command: "LABEL 7 O"
response_variable: result
```

### Why it belongs in the integration

The alternative, when you want to read `LABEL`, `MTRX`, `MAX`, or try something the entities don't model, is to open the serial port from another process. **A serial port has one owner** — the integration holds it, so a second opener either fails or interleaves bytes with the entity polling mid-frame.

`XAPCommand` already owns the device address, the terminator, the response parsing and the lock, so routing through it is both safer and less code than a side channel. The `unit` field addresses other XAPs on the expansion chain.

### Details

- **A refused command is returned as data, not raised.** Probing an unfamiliar unit means sending things it will reject; `XAPCommError`/`XAPRespError` come back as `{"command": ..., "error": ...}` rather than surfacing as an integration failure.
- **`return_count` defaults to 16.** It means "keep the last N whitespace-separated tokens", so a small value silently truncates — at 2, `LABEL 5 O` returns `["-", "Patio"]` and loses the `3L`. 16 is past the longest reply I've seen, and asking for more tokens than arrive simply returns what arrived, so the default shows the whole line.
- Registered against the first config entry to set up, and guarded by `hass.services.has_service` so a second entry doesn't re-register it.

### Testing

Used heavily against an XAP800 to read `MAX`, `GAIN`, `LABEL` and `MTRX` while commissioning zone levels — it's how I established what the unit actually held versus what the config believed.

---

Part of a series from my fork ([defl/xap_controller](https://github.com/defl/xap_controller)). Independent of the others.

🤖 Generated with [Claude Code](https://claude.com/claude-code)