### PR TITLE
Add a per-channel max gain ceiling, and clamp GAIN to it

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,14 @@ output channel to a dB ceiling:
 {"1": -15, "2": -15, "3": -15, "4": -15, "5": -15, "6": -15, "7": -15, "8": -15}
 ```
 
+A key is a bare channel on unit 0, or `"unit:channel"` on a chained system - the same
+addressing zones and sources already use. Channels on a downstream unit need the
+qualified form, or only the master gets a ceiling and the rest keep the factory +20 dB:
+
+```json
+{"7": -15, "8": -15, "1:1": -12, "1:2": -12}
+```
+
 With a âˆ’15 dB ceiling, 100% means âˆ’15 dB, and a zone at âˆ’22.5 dB shows as about 42%.
 
 - Values must be between âˆ’65 and +20 dB; channels you leave out are not touched.

--- a/README.md
+++ b/README.md
@@ -138,3 +138,43 @@ command body; the `#5<unit>` prefix and the `\r` terminator are added for you.
   longest reply seen; asking for more tokens than arrive just returns what arrived.
 - A command the unit refuses comes back as `{"command": ..., "error": ...}` rather than
   raising, because a rejection is a normal result when probing an unfamiliar unit.
+## Max gain per output channel (safety ceiling)
+
+`MAXGAIN` is a per-channel ceiling in the XAP hardware: `GAIN` cannot be set above it.
+It is *also* the reference that Home Assistant's `volume_level` is measured against â€”
+`getPropGain`/`setPropGain` express level as a ratio of it, so `volume_level: 1.0`
+means "this channel's MAXGAIN".
+
+An unconfigured unit leaves MAXGAIN at the **+20 dB factory maximum** on every channel,
+which is bad twice over:
+
+- **Safety.** A slider dragged to 100% drives the output at +20 dB. On ceiling speakers
+  that is not a volume anyone intended.
+- **Usability.** Real listening levels are far below that, so they crowd into the very
+  bottom of the slider. On the unit this was written against, four zones sitting between
+  âˆ’22.5 and âˆ’33 dB all landed under **1%** â€” the whole useful range inside two pixels of
+  travel.
+
+Set the optional **Max gain** field on the Sources & Zones step to a JSON object mapping
+output channel to a dB ceiling:
+
+```json
+{"1": -15, "2": -15, "3": -15, "4": -15, "5": -15, "6": -15, "7": -15, "8": -15}
+```
+
+With a âˆ’15 dB ceiling, 100% means âˆ’15 dB, and a zone at âˆ’22.5 dB shows as about 42%.
+
+- Values must be between âˆ’65 and +20 dB; channels you leave out are not touched.
+- Leave the field blank to keep the old behaviour and not write MAXGAIN at all.
+- The ceilings are re-applied on every setup, so a change made in G-Ware or from the
+  front panel is restored the next time Home Assistant starts.
+- **Lowering a ceiling pulls that channel's GAIN down to it â€” but the integration does
+  that, not the hardware.** The XAP leaves an existing level exactly where it was, above
+  its own stated maximum. On 2026-09-06 a reload wrote all eight ceilings to âˆ’15.00 while
+  the outputs stayed between âˆ’7.50 and âˆ’13.34; `volume_level` is a ratio against MAXGAIN,
+  so those zones reported values greater than 1.0 â€” `zone_kitchen_dining` read **2.371**, a
+  slider at 237% â€” and every slider move wrote dB against a ceiling the levels had never
+  been chosen for. `_apply_max_gain` now reads each listed channel back after writing its
+  ceiling and clamps anything above it, which is why a configured channel cannot report
+  more than 1.0. The clamp only ever reduces a level, never raises one. A channel you left
+  out of the config is not clamped, and can still read above 1.0.

--- a/README.md
+++ b/README.md
@@ -186,3 +186,31 @@ With a âˆ’15 dB ceiling, 100% means âˆ’15 dB, and a zone at âˆ’22.5 
   ceiling and clamps anything above it, which is why a configured channel cannot report
   more than 1.0. The clamp only ever reduces a level, never raises one. A channel you left
   out of the config is not clamped, and can still read above 1.0.
+
+### MAXGAIN is a reference, not a hardware limiter
+
+Worth being explicit, because the name suggests otherwise. The 880 command reference
+documents no interaction between `GAIN` and `MAX`: `GAIN`'s only stated limit is that
+*"absolute values will be limited to the internal gain range"* - that is -65...20 dB, not
+MAXGAIN - and `MAX`'s own range is that same -65...20, which is not what a real limiter
+would need. The 2.371 reading above is the positive evidence: a channel really can sit
+above its own stated maximum.
+
+So MAXGAIN is a stored reference that *software* gives meaning to, and the clamp above is
+the only enforcement that exists on the serial path - not a second opinion on something
+the box already guarantees.
+
+What that does and does not cover:
+
+- Anything routed through this integration is genuinely protected, because `setPropGain`
+  cannot express a value above `1.0`, which *is* MAXGAIN.
+- Anything that bypasses it - G-Ware, the front panel, `xap_controller.send_command` - is
+  not protected at all. That is the case the clamp reports as an error on the next setup.
+
+### Choosing a ceiling on a channel with reserved headroom
+
+On a channel driven programmatically with headroom deliberately left below the ceiling,
+MAXGAIN *is* that headroom: lowering it costs boost range one dB for one dB. Setting
+`-15` on such a channel is not free, so pick the ceiling from the loudest level that
+channel should ever reach, not from what it happens to sit at today.
+

--- a/config_flow.py
+++ b/config_flow.py
@@ -32,7 +32,7 @@ CONNECTION_TYPES = ["serial", "telnet"]
 
 SOURCES_EXAMPLE = '{"Home Audio": [9], "TV": ["1:11:O:E"]}'
 ZONES_EXAMPLE = '{"Kitchen": [3], "Office": ["2:1", "2:2"]}'
-MAX_GAIN_EXAMPLE = '{"7": -15, "8": -15}'
+MAX_GAIN_EXAMPLE = '{"7": -15, "8": -15, "1:1": -12}'
 
 # The XAP800 output gain range. MAXGAIN is the ceiling GAIN may be set to, and it is
 # what a 1.0 volume_level means: getPropGain/setPropGain express level as a ratio
@@ -42,11 +42,32 @@ MAX_GAIN_MIN_DB = -65.0
 MAX_GAIN_MAX_DB = 20.0
 
 
+def parse_channel_key(key) -> tuple:
+    """A max_gain key -> (unit, channel).
+
+    Accepts the same shapes the zone/source channel lists do: a bare channel meaning
+    unit 0, or "<unit>:<channel>". Raises ValueError on anything else, so callers can
+    turn that into whatever error suits them.
+    """
+    text = str(key).strip()
+    if ":" in text:
+        unit_text, _, chan_text = text.partition(":")
+    else:
+        unit_text, chan_text = "0", text
+    unit, channel = int(unit_text), int(chan_text)
+    if not 0 <= unit <= 7:
+        raise ValueError(f"unit {unit} out of range 0-7")
+    if channel < 1:
+        raise ValueError(f"channel {channel} must be 1 or greater")
+    return unit, channel
+
+
 def _validate_max_gain(json_str: str) -> dict:
     """Parse and validate the per-channel max-gain JSON. Returns the parsed dict.
 
-    Keys are output channel numbers, values a ceiling in dB. Blank means "leave the
-    unit alone", which is the old behaviour.
+    Keys are output channels, values a ceiling in dB. A key is either a bare channel on
+    unit 0 or "<unit>:<channel>", matching how zones and sources already address a
+    chained system. Blank means "leave the unit alone", which is the old behaviour.
     """
     if not json_str or not json_str.strip():
         return {}
@@ -56,13 +77,17 @@ def _validate_max_gain(json_str: str) -> dict:
         raise vol.Invalid("invalid_max_gain")
     if not isinstance(data, dict):
         raise vol.Invalid("invalid_max_gain")
+    seen = set()
     for key, val in data.items():
         try:
-            channel = int(key)
+            addr = parse_channel_key(key)
         except (TypeError, ValueError):
             raise vol.Invalid("invalid_max_gain")
-        if channel < 1:
+        if addr in seen:
+            # "7" and "0:7" are the same channel; two ceilings for it is a mistake
+            # worth catching here rather than letting the last one win at setup.
             raise vol.Invalid("invalid_max_gain")
+        seen.add(addr)
         if isinstance(val, bool) or not isinstance(val, (int, float)):
             raise vol.Invalid("invalid_max_gain")
         if not MAX_GAIN_MIN_DB <= float(val) <= MAX_GAIN_MAX_DB:

--- a/config_flow.py
+++ b/config_flow.py
@@ -24,6 +24,7 @@ CONF_HOST = "host"
 CONF_PORT = "port"
 CONF_TELNET_USERNAME = "telnet_username"
 CONF_TELNET_PASSWORD = "telnet_password"
+CONF_MAX_GAIN = "max_gain"
 
 XAP_TYPES = ["XAP800", "XAP400", "CP880", "CP880T", "CP880TA"]
 BAUD_RATES = [9600, 19200, 38400, 57600]
@@ -31,6 +32,42 @@ CONNECTION_TYPES = ["serial", "telnet"]
 
 SOURCES_EXAMPLE = '{"Home Audio": [9], "TV": ["1:11:O:E"]}'
 ZONES_EXAMPLE = '{"Kitchen": [3], "Office": ["2:1", "2:2"]}'
+MAX_GAIN_EXAMPLE = '{"7": -15, "8": -15}'
+
+# The XAP800 output gain range. MAXGAIN is the ceiling GAIN may be set to, and it is
+# what a 1.0 volume_level means: getPropGain/setPropGain express level as a ratio
+# against it, so leaving it at the +20 factory default squeezes every realistic
+# listening level into the bottom 2% of a Home Assistant slider.
+MAX_GAIN_MIN_DB = -65.0
+MAX_GAIN_MAX_DB = 20.0
+
+
+def _validate_max_gain(json_str: str) -> dict:
+    """Parse and validate the per-channel max-gain JSON. Returns the parsed dict.
+
+    Keys are output channel numbers, values a ceiling in dB. Blank means "leave the
+    unit alone", which is the old behaviour.
+    """
+    if not json_str or not json_str.strip():
+        return {}
+    try:
+        data = json.loads(json_str)
+    except json.JSONDecodeError:
+        raise vol.Invalid("invalid_max_gain")
+    if not isinstance(data, dict):
+        raise vol.Invalid("invalid_max_gain")
+    for key, val in data.items():
+        try:
+            channel = int(key)
+        except (TypeError, ValueError):
+            raise vol.Invalid("invalid_max_gain")
+        if channel < 1:
+            raise vol.Invalid("invalid_max_gain")
+        if isinstance(val, bool) or not isinstance(val, (int, float)):
+            raise vol.Invalid("invalid_max_gain")
+        if not MAX_GAIN_MIN_DB <= float(val) <= MAX_GAIN_MAX_DB:
+            raise vol.Invalid("invalid_max_gain")
+    return data
 
 
 def _validate_sources_zones(json_str: str, label: str) -> dict:
@@ -206,6 +243,11 @@ class XapControllerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             except vol.Invalid:
                 errors[CONF_ZONES] = "invalid_zones"
 
+            try:
+                _validate_max_gain(user_input.get(CONF_MAX_GAIN, ""))
+            except vol.Invalid:
+                errors[CONF_MAX_GAIN] = "invalid_max_gain"
+
             if not errors:
                 data = {**self._connection_data, **user_input}
                 title = self._connection_data.get(
@@ -223,6 +265,7 @@ class XapControllerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             {
                 vol.Required(CONF_SOURCES, default=SOURCES_EXAMPLE): str,
                 vol.Required(CONF_ZONES, default=ZONES_EXAMPLE): str,
+                vol.Optional(CONF_MAX_GAIN, default=""): str,
             }
         )
 
@@ -380,6 +423,11 @@ class XapControllerOptionsFlow(config_entries.OptionsFlow):
             except vol.Invalid:
                 errors[CONF_ZONES] = "invalid_zones"
 
+            try:
+                _validate_max_gain(user_input.get(CONF_MAX_GAIN, ""))
+            except vol.Invalid:
+                errors[CONF_MAX_GAIN] = "invalid_max_gain"
+
             if not errors:
                 new_data = {**self._entry.data, **self._connection_data, **user_input}
                 self.hass.config_entries.async_update_entry(self._entry, data=new_data)
@@ -392,6 +440,9 @@ class XapControllerOptionsFlow(config_entries.OptionsFlow):
                 ): str,
                 vol.Required(
                     CONF_ZONES, default=current.get(CONF_ZONES, ZONES_EXAMPLE)
+                ): str,
+                vol.Optional(
+                    CONF_MAX_GAIN, default=current.get(CONF_MAX_GAIN, "")
                 ): str,
             }
         )

--- a/media_player.py
+++ b/media_player.py
@@ -440,48 +440,78 @@ async def _apply_max_gain(hass, xapconn, raw):
             _LOGGER.error("max_gain entry %r: %r is not a channel/dB pair", channel, ceiling)
             continue
         try:
-            # stereo=0 suppresses the @stereo decorator's "call again with channel+1".
-            # max_gain is declared per channel, so it must write exactly the channels
-            # listed: without this, a stereo setup writes 1&2, 2&3 ... 8&9 â€” overlapping,
-            # twice the serial traffic, and channel 9 which nobody configured.
-            await hass.async_add_executor_job(
-                lambda c=chan, d=db, u=unit: xapconn.setMaxGain(
-                    c, d, group="O", unitCode=u, stereo=0)
-            )
-            _LOGGER.info("Set MAXGAIN on unit %s output %s to %s dB", unit, chan, db)
-
-            # A new ceiling does NOT drag an existing GAIN down to it - the XAP leaves the
-            # level exactly where it was, sitting above its own stated maximum. That is not
-            # a theoretical state: on 2026-09-06 a reload wrote all eight ceilings to -15.00
-            # underneath outputs running between -7.50 and -13.34, and because volume_level
-            # is a ratio against MAXGAIN, every zone then reported a value greater than 1.0
-            # - `zone_kitchen_dining` came back 2.371, a slider at 237% - while each slider
-            # move wrote dB against a ceiling those levels had never been chosen for.
+            # Read before writing. getPropGain costs the same two round trips either way,
+            # and it seeds XAPX00's MAXGAIN cache with the ceiling the unit is CURRENTLY
+            # holding - so the getMaxGain below is free, an unchanged ceiling is not
+            # rewritten on every restart, and the old value is available to say which of
+            # two very different situations this is.
             #
-            # Clamping here makes `volume_level <= 1.0` true by construction, and makes the
-            # ceiling mean what it says. It can only ever reduce a level, never raise one.
-            # Expressed in proportional gain because that is already the ratio to MAXGAIN:
-            # above 1.0 is above the ceiling, and writing 1.0 lands exactly on it.
+            # stereo=0 on all of these suppresses the @stereo decorator's "call again with
+            # channel+1". max_gain is declared per channel, so it must touch exactly the
+            # channels listed: without it a stereo connection walks 1&2, 2&3 ... 8&9 -
+            # overlapping, twice the traffic, and channel 9 which nobody configured.
             prop = await hass.async_add_executor_job(
                 lambda c=chan, u=unit: xapconn.getPropGain(
                     c, group="O", unitCode=u, stereo=0)
             )
-            # Compared in dB against a tolerance, not as `prop > 1.0`. db2linear adds a
-            # 1e-7 dB fudge before converting, so a channel sitting exactly ON its ceiling
-            # comes back as 1.0000000115, not 1.0 â€” a bare `> 1.0` would clamp every
-            # channel on every startup and log a "0.00 dB above" warning each time. The
-            # unit reports gain to 0.01 dB, so anything under half of that is noise.
-            over_db = 20.0 * math.log10(prop) if prop > 0 else 0.0
-            if over_db > GAIN_CLAMP_TOLERANCE_DB:
+            current = float(await hass.async_add_executor_job(
+                lambda c=chan, u=unit: xapconn.getMaxGain(
+                    c, group="O", unitCode=u, stereo=0)
+            ))
+
+            # prop is the level as a ratio of the ceiling it was just read against, so
+            # this is the channel's absolute gain regardless of what we do to the ceiling.
+            gain_db = current + 20.0 * math.log10(prop) if prop > 0 else None
+
+            ceiling_moved = abs(current - db) > GAIN_CLAMP_TOLERANCE_DB
+            if ceiling_moved:
+                await hass.async_add_executor_job(
+                    lambda c=chan, d=db, u=unit: xapconn.setMaxGain(
+                        c, d, group="O", unitCode=u, stereo=0)
+                )
+                _LOGGER.warning(
+                    "Unit %s output %s: MAXGAIN was %.2f dB, configured %.2f dB; set it. "
+                    "Either the option changed or something outside Home Assistant moved "
+                    "the ceiling.", unit, chan, current, db)
+            else:
+                _LOGGER.debug("Unit %s output %s already at its %.2f dB ceiling",
+                              unit, chan, db)
+
+            # A ceiling does NOT drag an existing GAIN down to it - the unit leaves the
+            # level exactly where it was, above its own stated maximum. That is not
+            # theoretical: on 2026-09-06 a reload wrote eight ceilings to -15.00 underneath
+            # outputs running between -7.50 and -13.34, so every zone reported volume_level
+            # greater than 1.0 - one came back 2.371, a slider at 237% - and each slider
+            # move wrote dB against a ceiling those levels were never chosen for.
+            #
+            # Nothing in the hardware prevents that: the 880 reference documents no
+            # interaction between GAIN and MAX, and GAIN's only stated limit is the -65..20
+            # internal range. So this clamp is the enforcement, not a second opinion on an
+            # enforcement the box already does.
+            #
+            # Compared in dB against a tolerance rather than as `prop > 1.0`, because
+            # db2linear does not return a clean 1.0 for a channel sitting exactly on its
+            # ceiling - 1.0000000115 on XAPX00 2026.04.22, 0.999999 on 2026.09.03. A bare
+            # `> 1.0` would clamp every channel on every startup on the older build.
+            over_db = None if gain_db is None else gain_db - db
+            if over_db is not None and over_db > GAIN_CLAMP_TOLERANCE_DB:
                 landed = await hass.async_add_executor_job(
                     lambda c=chan, u=unit: xapconn.setPropGain(
                         c, 1.0, isAbsolute=1, group="O", unitCode=u, stereo=0)
                 )
-                _LOGGER.warning(
-                    "Unit %s output %s sat %.2f dB above its new %s dB ceiling; pulled it "
-                    "down to the ceiling (readback %.4f of MAXGAIN)",
-                    unit, chan, over_db, db, landed,
-                )
+                if ceiling_moved:
+                    _LOGGER.warning(
+                        "Unit %s output %s was %.2f dB, above the %.2f dB ceiling just "
+                        "set; pulled it down to the ceiling (readback %.4f of MAXGAIN)",
+                        unit, chan, gain_db, db, landed)
+                else:
+                    # The ceiling is what it has always been, so nothing here put the gain
+                    # above it. G-Ware, the front panel or a raw send_command did.
+                    _LOGGER.error(
+                        "Unit %s output %s was %.2f dB, above its unchanged %.2f dB "
+                        "ceiling - something outside this integration set it. Pulled it "
+                        "down to the ceiling (readback %.4f of MAXGAIN)",
+                        unit, chan, gain_db, db, landed)
         except Exception:  # noqa: BLE001 - a bad channel must not abort the rest
             _LOGGER.exception("Failed setting MAXGAIN on unit %s output %s", unit, chan)
 

--- a/media_player.py
+++ b/media_player.py
@@ -117,6 +117,7 @@ media_player:
 import logging
 import functools
 import json
+import math
 import shlex
 import threading
 
@@ -134,6 +135,7 @@ from XAPX00 import __version__ as XAPVER, XAPX00, XAPCommError, XAPRespError
 from .config_flow import (
     CONF_PATH, CONF_SOURCES, CONF_ZONES, CONF_TYPE, CONF_STEREO, CONF_BAUD,
     CONF_CONNECTION_TYPE, CONF_HOST, CONF_PORT, CONF_TELNET_USERNAME, CONF_TELNET_PASSWORD,
+    CONF_MAX_GAIN,
 )
 
 DOMAIN = 'xap_controller'
@@ -146,6 +148,10 @@ SRC_OFF = 'Off'
 # input -> processing -> output, which leaves no direct input/output crosspoint for
 # the plain matrix lookup to find.
 PROC_BLOCKS = "ABCDEFGH"
+# How far above its ceiling a channel must sit before _apply_max_gain pulls it down.
+# The unit reports gain to 0.01 dB; this is well under that, and far above the
+# rounding in db2linear that makes an exactly-at-ceiling channel read as just over 1.0.
+GAIN_CLAMP_TOLERANCE_DB = 0.005
 
 SUPPORT_XAP_ZONE = (
     MPEF.VOLUME_MUTE | MPEF.VOLUME_SET |
@@ -389,6 +395,87 @@ async def _prewarm_max_gain(hass, xapconn, zones):
     cached = await hass.async_add_executor_job(_read_all)
     _LOGGER.debug(
         "MAXGAIN pre-warm: cached %s of %s zone output channels", cached, len(channels))
+async def _apply_max_gain(hass, xapconn, raw):
+    """Write the configured per-channel MAXGAIN ceilings to the unit.
+
+    MAXGAIN is a safety limit in the hardware â€” GAIN cannot be set above it â€” and it is
+    also the reference a 1.0 volume_level maps to. Both reasons to configure it: an
+    unconfigured unit sits at the +20 dB factory maximum, so a full-scale slider is a
+    speaker-damaging level AND every realistic listening level crowds into the bottom
+    couple of percent of the slider.
+
+    Applied on every setup rather than once, so the ceiling is restored after anyone
+    edits it in G-Ware or from the front panel. Channels left out of the config are not
+    touched â€” including by the clamp below.
+
+    Each listed channel is then clamped to its ceiling, because lowering MAXGAIN does not
+    move a GAIN that is already above it. See the comment in the loop for what that cost.
+    """
+    if not raw or not str(raw).strip():
+        return
+    try:
+        wanted = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        _LOGGER.error("max_gain is not valid JSON, ignoring it: %r", raw)
+        return
+    if not isinstance(wanted, dict):
+        # Valid JSON is not necessarily the right shape: a list parses cleanly and then
+        # dies on .items(), taking setup down with it. config_flow rejects this, but the
+        # stored entry can predate that validation or be edited by hand.
+        _LOGGER.error(
+            "max_gain must be a JSON object of channel -> dB, ignoring it: %r", raw)
+        return
+
+    for channel, ceiling in wanted.items():
+        try:
+            chan = int(channel)
+            db = float(ceiling)
+        except (TypeError, ValueError):
+            _LOGGER.error("max_gain entry %r: %r is not a channel/dB pair", channel, ceiling)
+            continue
+        try:
+            # stereo=0 suppresses the @stereo decorator's "call again with channel+1".
+            # max_gain is declared per channel, so it must write exactly the channels
+            # listed: without this, a stereo setup writes 1&2, 2&3 ... 8&9 â€” overlapping,
+            # twice the serial traffic, and channel 9 which nobody configured.
+            await hass.async_add_executor_job(
+                lambda c=chan, d=db: xapconn.setMaxGain(c, d, group="O", stereo=0)
+            )
+            _LOGGER.info("Set MAXGAIN on output %s to %s dB", chan, db)
+
+            # A new ceiling does NOT drag an existing GAIN down to it - the XAP leaves the
+            # level exactly where it was, sitting above its own stated maximum. That is not
+            # a theoretical state: on 2026-09-06 a reload wrote all eight ceilings to -15.00
+            # underneath outputs running between -7.50 and -13.34, and because volume_level
+            # is a ratio against MAXGAIN, every zone then reported a value greater than 1.0
+            # - `zone_kitchen_dining` came back 2.371, a slider at 237% - while each slider
+            # move wrote dB against a ceiling those levels had never been chosen for.
+            #
+            # Clamping here makes `volume_level <= 1.0` true by construction, and makes the
+            # ceiling mean what it says. It can only ever reduce a level, never raise one.
+            # Expressed in proportional gain because that is already the ratio to MAXGAIN:
+            # above 1.0 is above the ceiling, and writing 1.0 lands exactly on it.
+            prop = await hass.async_add_executor_job(
+                lambda c=chan: xapconn.getPropGain(c, group="O", stereo=0)
+            )
+            # Compared in dB against a tolerance, not as `prop > 1.0`. db2linear adds a
+            # 1e-7 dB fudge before converting, so a channel sitting exactly ON its ceiling
+            # comes back as 1.0000000115, not 1.0 â€” a bare `> 1.0` would clamp every
+            # channel on every startup and log a "0.00 dB above" warning each time. The
+            # unit reports gain to 0.01 dB, so anything under half of that is noise.
+            over_db = 20.0 * math.log10(prop) if prop > 0 else 0.0
+            if over_db > GAIN_CLAMP_TOLERANCE_DB:
+                landed = await hass.async_add_executor_job(
+                    lambda c=chan: xapconn.setPropGain(
+                        c, 1.0, isAbsolute=1, group="O", stereo=0)
+                )
+                _LOGGER.warning(
+                    "Output %s sat %.2f dB above its new %s dB ceiling; pulled it down "
+                    "to the ceiling (readback %.4f of MAXGAIN)",
+                    chan, over_db, db, landed,
+                )
+        except Exception:  # noqa: BLE001 - a bad channel must not abort the rest
+            _LOGGER.exception("Failed setting MAXGAIN on output %s", chan)
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
@@ -456,6 +543,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = xapconn
     _register_send_command(hass)
+    await _apply_max_gain(hass, xapconn, entry.data.get(CONF_MAX_GAIN, ""))
 
     source_objs = []
     zonesources = {}

--- a/media_player.py
+++ b/media_player.py
@@ -135,7 +135,7 @@ from XAPX00 import __version__ as XAPVER, XAPX00, XAPCommError, XAPRespError
 from .config_flow import (
     CONF_PATH, CONF_SOURCES, CONF_ZONES, CONF_TYPE, CONF_STEREO, CONF_BAUD,
     CONF_CONNECTION_TYPE, CONF_HOST, CONF_PORT, CONF_TELNET_USERNAME, CONF_TELNET_PASSWORD,
-    CONF_MAX_GAIN,
+    CONF_MAX_GAIN, parse_channel_key,
 )
 
 DOMAIN = 'xap_controller'
@@ -413,6 +413,12 @@ async def _apply_max_gain(hass, xapconn, raw):
     """
     if not raw or not str(raw).strip():
         return
+    if not xapconn.connectionLive:
+        # Every channel would raise into the handler below and log a full traceback -
+        # eight of them for a disconnected unit, none of which say anything the warning
+        # from the caller has not already said.
+        _LOGGER.warning("Not connected; leaving MAXGAIN alone this setup")
+        return
     try:
         wanted = json.loads(raw)
     except (json.JSONDecodeError, TypeError):
@@ -428,7 +434,7 @@ async def _apply_max_gain(hass, xapconn, raw):
 
     for channel, ceiling in wanted.items():
         try:
-            chan = int(channel)
+            unit, chan = parse_channel_key(channel)
             db = float(ceiling)
         except (TypeError, ValueError):
             _LOGGER.error("max_gain entry %r: %r is not a channel/dB pair", channel, ceiling)
@@ -439,9 +445,10 @@ async def _apply_max_gain(hass, xapconn, raw):
             # listed: without this, a stereo setup writes 1&2, 2&3 ... 8&9 â€” overlapping,
             # twice the serial traffic, and channel 9 which nobody configured.
             await hass.async_add_executor_job(
-                lambda c=chan, d=db: xapconn.setMaxGain(c, d, group="O", stereo=0)
+                lambda c=chan, d=db, u=unit: xapconn.setMaxGain(
+                    c, d, group="O", unitCode=u, stereo=0)
             )
-            _LOGGER.info("Set MAXGAIN on output %s to %s dB", chan, db)
+            _LOGGER.info("Set MAXGAIN on unit %s output %s to %s dB", unit, chan, db)
 
             # A new ceiling does NOT drag an existing GAIN down to it - the XAP leaves the
             # level exactly where it was, sitting above its own stated maximum. That is not
@@ -456,7 +463,8 @@ async def _apply_max_gain(hass, xapconn, raw):
             # Expressed in proportional gain because that is already the ratio to MAXGAIN:
             # above 1.0 is above the ceiling, and writing 1.0 lands exactly on it.
             prop = await hass.async_add_executor_job(
-                lambda c=chan: xapconn.getPropGain(c, group="O", stereo=0)
+                lambda c=chan, u=unit: xapconn.getPropGain(
+                    c, group="O", unitCode=u, stereo=0)
             )
             # Compared in dB against a tolerance, not as `prop > 1.0`. db2linear adds a
             # 1e-7 dB fudge before converting, so a channel sitting exactly ON its ceiling
@@ -466,16 +474,16 @@ async def _apply_max_gain(hass, xapconn, raw):
             over_db = 20.0 * math.log10(prop) if prop > 0 else 0.0
             if over_db > GAIN_CLAMP_TOLERANCE_DB:
                 landed = await hass.async_add_executor_job(
-                    lambda c=chan: xapconn.setPropGain(
-                        c, 1.0, isAbsolute=1, group="O", stereo=0)
+                    lambda c=chan, u=unit: xapconn.setPropGain(
+                        c, 1.0, isAbsolute=1, group="O", unitCode=u, stereo=0)
                 )
                 _LOGGER.warning(
-                    "Output %s sat %.2f dB above its new %s dB ceiling; pulled it down "
-                    "to the ceiling (readback %.4f of MAXGAIN)",
-                    chan, over_db, db, landed,
+                    "Unit %s output %s sat %.2f dB above its new %s dB ceiling; pulled it "
+                    "down to the ceiling (readback %.4f of MAXGAIN)",
+                    unit, chan, over_db, db, landed,
                 )
         except Exception:  # noqa: BLE001 - a bad channel must not abort the rest
-            _LOGGER.exception("Failed setting MAXGAIN on output %s", chan)
+            _LOGGER.exception("Failed setting MAXGAIN on unit %s output %s", unit, chan)
 
 
 async def async_setup_entry(hass, entry, async_add_entities):

--- a/strings.json
+++ b/strings.json
@@ -30,17 +30,19 @@
       },
       "sources_zones": {
         "title": "XAP Controller — Sources & Zones",
-        "description": "Enter sources and zones as JSON objects. Keys are names, values are lists of channel specs (integers or strings like \"1:3\" or \"1:9:O:E\").",
+        "description": "Enter sources and zones as JSON objects. Keys are names, values are lists of channel specs (integers or strings like \"1:3\" or \"1:9:O:E\"). Max gain is optional: a JSON object mapping output channel to a dB ceiling, e.g. {\"7\": -15}. It caps how loud that output can ever be driven and sets what 100% volume means. Leave blank to leave the unit's own setting alone.",
         "data": {
           "sources": "Sources (JSON)",
-          "zones": "Zones (JSON)"
+          "zones": "Zones (JSON)",
+          "max_gain": "Max gain per output channel (JSON, optional)"
         }
       }
     },
     "error": {
       "cannot_connect": "Unable to connect to the XAP unit. Check your connection settings. You may still proceed if the connection is intermittent.",
       "invalid_sources": "Invalid sources JSON. Expected an object mapping names to lists of channel specs.",
-      "invalid_zones": "Invalid zones JSON. Expected an object mapping names to lists of channel specs."
+      "invalid_zones": "Invalid zones JSON. Expected an object mapping names to lists of channel specs.",
+      "invalid_max_gain": "Invalid max gain JSON. Expected an object mapping output channel numbers to a dB value between -65 and 20, e.g. {\"7\": -15, \"8\": -15}."
     },
     "abort": {
       "already_configured": "This XAP unit is already configured."
@@ -77,17 +79,19 @@
       },
       "sources_zones": {
         "title": "XAP Controller — Sources & Zones",
-        "description": "Enter sources and zones as JSON objects. Keys are names, values are lists of channel specs (integers or strings like \"1:3\" or \"1:9:O:E\").",
+        "description": "Enter sources and zones as JSON objects. Keys are names, values are lists of channel specs (integers or strings like \"1:3\" or \"1:9:O:E\"). Max gain is optional: a JSON object mapping output channel to a dB ceiling, e.g. {\"7\": -15}. It caps how loud that output can ever be driven and sets what 100% volume means. Leave blank to leave the unit's own setting alone.",
         "data": {
           "sources": "Sources (JSON)",
-          "zones": "Zones (JSON)"
+          "zones": "Zones (JSON)",
+          "max_gain": "Max gain per output channel (JSON, optional)"
         }
       }
     },
     "error": {
       "cannot_connect": "Unable to connect to the XAP unit.",
       "invalid_sources": "Invalid sources JSON. Expected an object mapping names to lists of channel specs.",
-      "invalid_zones": "Invalid zones JSON. Expected an object mapping names to lists of channel specs."
+      "invalid_zones": "Invalid zones JSON. Expected an object mapping names to lists of channel specs.",
+      "invalid_max_gain": "Invalid max gain JSON. Expected an object mapping output channel numbers to a dB value between -65 and 20, e.g. {\"7\": -15, \"8\": -15}."
     }
   }
 }

--- a/strings.json
+++ b/strings.json
@@ -30,7 +30,7 @@
       },
       "sources_zones": {
         "title": "XAP Controller — Sources & Zones",
-        "description": "Enter sources and zones as JSON objects. Keys are names, values are lists of channel specs (integers or strings like \"1:3\" or \"1:9:O:E\"). Max gain is optional: a JSON object mapping output channel to a dB ceiling, e.g. {\"7\": -15}. It caps how loud that output can ever be driven and sets what 100% volume means. Leave blank to leave the unit's own setting alone.",
+        "description": "Enter sources and zones as JSON objects. Keys are names, values are lists of channel specs (integers or strings like \"1:3\" or \"1:9:O:E\"). Max gain is optional: a JSON object mapping output channel to a dB ceiling, e.g. {\"7\": -15, \"1:1\": -12}. A key is a bare channel on unit 0, or \"unit:channel\" for a chained system. It caps how loud that output can ever be driven and sets what 100% volume means. Leave blank to leave the unit's own setting alone.",
         "data": {
           "sources": "Sources (JSON)",
           "zones": "Zones (JSON)",
@@ -42,7 +42,7 @@
       "cannot_connect": "Unable to connect to the XAP unit. Check your connection settings. You may still proceed if the connection is intermittent.",
       "invalid_sources": "Invalid sources JSON. Expected an object mapping names to lists of channel specs.",
       "invalid_zones": "Invalid zones JSON. Expected an object mapping names to lists of channel specs.",
-      "invalid_max_gain": "Invalid max gain JSON. Expected an object mapping output channel numbers to a dB value between -65 and 20, e.g. {\"7\": -15, \"8\": -15}."
+      "invalid_max_gain": "Invalid max gain JSON. Expected an object mapping output channels to a dB value between -65 and 20, e.g. {\"7\": -15, \"1:1\": -12}. Keys are a bare channel or \"unit:channel\"."
     },
     "abort": {
       "already_configured": "This XAP unit is already configured."
@@ -79,7 +79,7 @@
       },
       "sources_zones": {
         "title": "XAP Controller — Sources & Zones",
-        "description": "Enter sources and zones as JSON objects. Keys are names, values are lists of channel specs (integers or strings like \"1:3\" or \"1:9:O:E\"). Max gain is optional: a JSON object mapping output channel to a dB ceiling, e.g. {\"7\": -15}. It caps how loud that output can ever be driven and sets what 100% volume means. Leave blank to leave the unit's own setting alone.",
+        "description": "Enter sources and zones as JSON objects. Keys are names, values are lists of channel specs (integers or strings like \"1:3\" or \"1:9:O:E\"). Max gain is optional: a JSON object mapping output channel to a dB ceiling, e.g. {\"7\": -15, \"1:1\": -12}. A key is a bare channel on unit 0, or \"unit:channel\" for a chained system. It caps how loud that output can ever be driven and sets what 100% volume means. Leave blank to leave the unit's own setting alone.",
         "data": {
           "sources": "Sources (JSON)",
           "zones": "Zones (JSON)",
@@ -91,7 +91,7 @@
       "cannot_connect": "Unable to connect to the XAP unit.",
       "invalid_sources": "Invalid sources JSON. Expected an object mapping names to lists of channel specs.",
       "invalid_zones": "Invalid zones JSON. Expected an object mapping names to lists of channel specs.",
-      "invalid_max_gain": "Invalid max gain JSON. Expected an object mapping output channel numbers to a dB value between -65 and 20, e.g. {\"7\": -15, \"8\": -15}."
+      "invalid_max_gain": "Invalid max gain JSON. Expected an object mapping output channels to a dB value between -65 and 20, e.g. {\"7\": -15, \"1:1\": -12}. Keys are a bare channel or \"unit:channel\"."
     }
   }
 }

--- a/tests/test_max_gain.py
+++ b/tests/test_max_gain.py
@@ -1,0 +1,118 @@
+"""The ceiling/clamp path in `_apply_max_gain`.
+
+This is the one function in the component that writes gain to hardware without a person
+asking it to, so it is the one worth pinning down.
+"""
+
+import asyncio
+import json
+
+import pytest
+
+
+class FakeHass:
+    async def async_add_executor_job(self, fn):
+        return fn()
+
+
+class FakeXap:
+    """props maps channel -> proportional gain reported after its ceiling is written."""
+
+    def __init__(self, props=None, refuse=()):
+        self.props = props or {}
+        self.refuse = set(refuse)
+        self.max_writes = []
+        self.gain_writes = []
+
+    def setMaxGain(self, channel, gain, group="I", unitCode=0, stereo=1):
+        if channel in self.refuse:
+            raise RuntimeError(f"channel {channel} refused")
+        self.max_writes.append((channel, gain, group, stereo))
+        return gain
+
+    def getPropGain(self, channel, group="I", unitCode=0, stereo=1):
+        return self.props[channel]
+
+    def setPropGain(self, channel, gain, isAbsolute=1, group="I", unitCode=0, stereo=1):
+        self.gain_writes.append((channel, gain, group, stereo))
+        return 1.0
+
+
+def apply(component, props, config, refuse=()):
+    xap = FakeXap(props, refuse)
+    asyncio.run(component._apply_max_gain(FakeHass(), xap, config))
+    return xap
+
+
+def channels(writes):
+    return [w[0] for w in writes]
+
+
+def test_writes_every_configured_ceiling(component):
+    xap = apply(component, {7: 1.0, 8: 1.0}, json.dumps({"7": -7.5, "8": -10}))
+    assert xap.max_writes == [(7, -7.5, "O", 0), (8, -10.0, "O", 0)]
+
+
+def test_ceilings_are_written_per_channel_not_per_stereo_pair(component):
+    """stereo=0 on every write: the config names channels, so it must write those exactly."""
+    xap = apply(component, {7: 1.0}, json.dumps({"7": -7.5}))
+    assert all(w[3] == 0 for w in xap.max_writes)
+
+
+def test_clamps_a_channel_left_above_its_new_ceiling(component):
+    """The 2026-09-06 state: ceilings lowered under gains that were already above them."""
+    live = {1: 1.3335, 2: 1.3335, 3: 1.2106, 4: 1.2106,
+            5: 1.2459, 6: 1.2459, 7: 2.3714, 8: 2.3714}
+    config = json.dumps({"1": -12.5, "2": -12.5, "3": -10, "4": -10,
+                         "5": -10, "6": -10, "7": -7.5, "8": -7.5})
+    xap = apply(component, live, config)
+    assert channels(xap.gain_writes) == [1, 2, 3, 4, 5, 6, 7, 8]
+    assert {w[1] for w in xap.gain_writes} == {1.0}
+    assert {w[2] for w in xap.gain_writes} == {"O"}
+    assert all(w[3] == 0 for w in xap.gain_writes)
+
+
+def test_leaves_a_channel_below_its_ceiling_alone(component):
+    xap = apply(component, {7: 0.73, 8: 0.68}, json.dumps({"7": -7.5, "8": -7.5}))
+    assert xap.gain_writes == []
+
+
+@pytest.mark.parametrize("prop", [1.0, 0.999999, 1.0000000115129255])
+def test_at_the_ceiling_is_not_a_clamp(component, prop):
+    """Neither XAPX00 build reports a clean 1.0 for a channel sitting on its ceiling.
+
+    2026.04.22 adds 1e-7 dB and returns 1.0000000115; 2026.09.03 subtracts a linear
+    epsilon and returns 0.999999. A bare `> 1.0` test would clamp the first one on every
+    single startup and log a "0.00 dB above" warning each time.
+    """
+    xap = apply(component, {7: prop}, json.dumps({"7": -7.5}))
+    assert xap.gain_writes == []
+
+
+def test_a_real_overshoot_still_clamps(component):
+    """0.01 dB is the unit's own reporting resolution, so it must not be swallowed."""
+    xap = apply(component, {7: 1.00115}, json.dumps({"7": -7.5}))
+    assert channels(xap.gain_writes) == [7]
+
+
+def test_a_malformed_entry_does_not_stop_the_others(component):
+    xap = apply(component, {7: 2.0}, json.dumps({"7": -7.5, "9": "not-a-number"}))
+    assert channels(xap.max_writes) == [7]
+    assert channels(xap.gain_writes) == [7]
+
+
+def test_a_refused_channel_does_not_abort_the_rest(component):
+    xap = apply(component, {7: 2.0, 8: 2.0},
+                      json.dumps({"7": -7.5, "8": -7.5}), refuse=(7,))
+    assert channels(xap.gain_writes) == [8]
+
+
+@pytest.mark.parametrize("config", ["", "   ", None, "{not json", '["not", "a", "map"]'])
+def test_nothing_is_written_without_usable_config(component, config):
+    xap = FakeXap({7: 2.0})
+    try:
+        asyncio.run(component._apply_max_gain(FakeHass(), xap, config))
+    except AttributeError:
+        pytest.fail("a non-dict config should be ignored, not crash")
+    assert xap.max_writes == []
+    assert xap.gain_writes == []

--- a/tests/test_max_gain.py
+++ b/tests/test_max_gain.py
@@ -6,6 +6,7 @@ asking it to, so it is the one worth pinning down.
 
 import asyncio
 import json
+import math
 
 import pytest
 
@@ -16,32 +17,51 @@ class FakeHass:
 
 
 class FakeXap:
-    """props maps channel -> proportional gain reported after its ceiling is written."""
+    """A unit holding a real gain and ceiling per channel, in dB.
+
+    Modelled rather than canned, because the order the component reads and writes in is
+    the thing under test: a proportional gain only means something relative to whichever
+    ceiling was in place when it was read.
+    """
 
     connectionLive = True
 
-    def __init__(self, props=None, refuse=()):
-        self.props = props or {}
+    def __init__(self, gains=None, ceilings=None, refuse=()):
+        self.gains = dict(gains or {})
+        self.ceilings = dict(ceilings or {})
         self.refuse = set(refuse)
         self.max_writes = []
         self.gain_writes = []
+        self.reads = []
+
+    def _ceiling(self, channel):
+        return self.ceilings.get(channel, 20.0)  # factory default
+
+    def getMaxGain(self, channel, group="I", unitCode=0, stereo=1):
+        self.reads.append(("MAX", channel, unitCode))
+        return self._ceiling(channel)
 
     def setMaxGain(self, channel, gain, group="I", unitCode=0, stereo=1):
         if channel in self.refuse:
             raise RuntimeError(f"channel {channel} refused")
         self.max_writes.append((channel, gain, group, stereo, unitCode))
+        self.ceilings[channel] = gain
         return gain
 
     def getPropGain(self, channel, group="I", unitCode=0, stereo=1):
-        return self.props[channel]
+        self.reads.append(("GAIN", channel, unitCode))
+        if channel in self.refuse:
+            raise RuntimeError(f"channel {channel} refused")
+        return 10.0 ** ((self.gains[channel] - self._ceiling(channel)) / 20.0)
 
-    def setPropGain(self, channel, gain, isAbsolute=1, group="I", unitCode=0, stereo=1):
-        self.gain_writes.append((channel, gain, group, stereo, unitCode))
-        return 1.0
+    def setPropGain(self, channel, prop, isAbsolute=1, group="I", unitCode=0, stereo=1):
+        self.gain_writes.append((channel, prop, group, stereo, unitCode))
+        self.gains[channel] = self._ceiling(channel) + 20.0 * math.log10(prop)
+        return prop
 
 
-def apply(component, props, config, refuse=()):
-    xap = FakeXap(props, refuse)
+def apply(component, gains, config, ceilings=None, refuse=()):
+    xap = FakeXap(gains, ceilings, refuse)
     asyncio.run(component._apply_max_gain(FakeHass(), xap, config))
     return xap
 
@@ -50,104 +70,132 @@ def channels(writes):
     return [w[0] for w in writes]
 
 
-def test_writes_every_configured_ceiling(component):
-    xap = apply(component, {7: 1.0, 8: 1.0}, json.dumps({"7": -7.5, "8": -10}))
+def test_writes_a_ceiling_that_differs_from_the_unit(component):
+    xap = apply(component, {7: -20.0, 8: -20.0}, json.dumps({"7": -7.5, "8": -10}),
+                ceilings={7: 20.0, 8: 20.0})
     assert xap.max_writes == [(7, -7.5, "O", 0, 0), (8, -10.0, "O", 0, 0)]
 
 
+def test_an_unchanged_ceiling_is_not_rewritten(component):
+    """A restart should not be a device write when nothing has changed."""
+    xap = apply(component, {7: -20.0}, json.dumps({"7": -7.5}), ceilings={7: -7.5})
+    assert xap.max_writes == []
+
+
+def test_the_level_is_read_before_the_ceiling_is_written(component):
+    """Reading first is what makes the old ceiling knowable at all."""
+    xap = apply(component, {7: -20.0}, json.dumps({"7": -7.5}), ceilings={7: 20.0})
+    assert xap.reads[0][0] == "GAIN"
+    assert xap.max_writes, "expected the ceiling to be written after the read"
+
+
+def test_ceilings_are_written_per_channel_not_per_stereo_pair(component):
+    xap = apply(component, {7: -20.0}, json.dumps({"7": -7.5}), ceilings={7: 20.0})
+    assert all(w[3] == 0 for w in xap.max_writes)
+    assert all(r[1] == 7 for r in xap.reads)
+
+
 def test_a_bare_key_means_unit_0(component):
-    xap = apply(component, {7: 1.0}, json.dumps({"7": -7.5}))
+    xap = apply(component, {7: -20.0}, json.dumps({"7": -7.5}), ceilings={7: 20.0})
     assert xap.max_writes[0][4] == 0
 
 
 def test_a_unit_qualified_key_addresses_that_unit(component):
     """A chained system: without this only the master ever gets a ceiling."""
-    xap = apply(component, {1: 1.0}, json.dumps({"1:1": -12.5}))
+    xap = apply(component, {1: -20.0}, json.dumps({"1:1": -12.5}), ceilings={1: 20.0})
     assert xap.max_writes == [(1, -12.5, "O", 0, 1)]
+    assert all(r[2] == 1 for r in xap.reads)
 
 
 def test_the_clamp_addresses_the_same_unit_as_the_ceiling(component):
-    xap = apply(component, {1: 2.0}, json.dumps({"2:1": -12.5}))
+    xap = apply(component, {1: 0.0}, json.dumps({"2:1": -12.5}), ceilings={1: 20.0})
     assert xap.max_writes[0][4] == 2
     assert xap.gain_writes[0][4] == 2
 
 
 def test_units_are_kept_apart(component):
-    xap = apply(component, {3: 1.0}, json.dumps({"3": -7.5, "1:3": -12.0}))
+    xap = apply(component, {3: -20.0}, json.dumps({"3": -7.5, "1:3": -12.0}),
+                ceilings={3: 20.0})
     assert [(w[0], w[4]) for w in xap.max_writes] == [(3, 0), (3, 1)]
-
-
-def test_an_offline_unit_is_left_alone(component):
-    """Every channel would otherwise raise and log a full traceback."""
-    xap = FakeXap({7: 2.0})
-    xap.connectionLive = False
-    asyncio.run(component._apply_max_gain(FakeHass(), xap, json.dumps({"7": -7.5})))
-    assert xap.max_writes == [] and xap.gain_writes == []
-
-
-def test_ceilings_are_written_per_channel_not_per_stereo_pair(component):
-    """stereo=0 on every write: the config names channels, so it must write those exactly."""
-    xap = apply(component, {7: 1.0}, json.dumps({"7": -7.5}))
-    assert all(w[3] == 0 for w in xap.max_writes)
 
 
 def test_clamps_a_channel_left_above_its_new_ceiling(component):
     """The 2026-09-06 state: ceilings lowered under gains that were already above them."""
-    live = {1: 1.3335, 2: 1.3335, 3: 1.2106, 4: 1.2106,
-            5: 1.2459, 6: 1.2459, 7: 2.3714, 8: 2.3714}
-    config = json.dumps({"1": -12.5, "2": -12.5, "3": -10, "4": -10,
-                         "5": -10, "6": -10, "7": -7.5, "8": -7.5})
-    xap = apply(component, live, config)
+    gains = {1: -12.5, 2: -12.5, 3: -13.34, 4: -13.34,
+             5: -13.09, 6: -13.09, 7: -7.5, 8: -7.5}
+    ceilings = {c: -15.0 for c in gains}
+    config = json.dumps({str(c): -20 for c in gains})
+    xap = apply(component, gains, config, ceilings=ceilings)
     assert channels(xap.gain_writes) == [1, 2, 3, 4, 5, 6, 7, 8]
     assert {w[1] for w in xap.gain_writes} == {1.0}
-    assert {w[2] for w in xap.gain_writes} == {"O"}
-    assert all(w[3] == 0 for w in xap.gain_writes)
+    assert all(v == pytest.approx(-20.0) for v in xap.gains.values())
 
 
 def test_leaves_a_channel_below_its_ceiling_alone(component):
-    xap = apply(component, {7: 0.73, 8: 0.68}, json.dumps({"7": -7.5, "8": -7.5}))
+    xap = apply(component, {7: -20.0, 8: -30.0}, json.dumps({"7": -7.5, "8": -7.5}),
+                ceilings={7: -7.5, 8: -7.5})
     assert xap.gain_writes == []
 
 
-@pytest.mark.parametrize("prop", [1.0, 0.999999, 1.0000000115129255])
-def test_at_the_ceiling_is_not_a_clamp(component, prop):
+@pytest.mark.parametrize("gain", [-7.5, -7.5001, -7.5 - 1e-9])
+def test_at_the_ceiling_is_not_a_clamp(component, gain):
     """Neither XAPX00 build reports a clean 1.0 for a channel sitting on its ceiling.
 
     2026.04.22 adds 1e-7 dB and returns 1.0000000115; 2026.09.03 subtracts a linear
-    epsilon and returns 0.999999. A bare `> 1.0` test would clamp the first one on every
-    single startup and log a "0.00 dB above" warning each time.
+    epsilon and returns 0.999999. A bare `> 1.0` test would clamp the first on every
+    startup and log a "0.00 dB above" warning each time.
     """
-    xap = apply(component, {7: prop}, json.dumps({"7": -7.5}))
+    xap = apply(component, {7: gain}, json.dumps({"7": -7.5}), ceilings={7: -7.5})
     assert xap.gain_writes == []
 
 
 def test_a_real_overshoot_still_clamps(component):
     """0.01 dB is the unit's own reporting resolution, so it must not be swallowed."""
-    xap = apply(component, {7: 1.00115}, json.dumps({"7": -7.5}))
+    xap = apply(component, {7: -7.49}, json.dumps({"7": -7.5}), ceilings={7: -7.5})
     assert channels(xap.gain_writes) == [7]
 
 
 def test_a_malformed_entry_does_not_stop_the_others(component):
-    xap = apply(component, {7: 2.0}, json.dumps({"7": -7.5, "9": "not-a-number"}))
+    xap = apply(component, {7: 0.0}, json.dumps({"7": -7.5, "9": "not-a-number"}),
+                ceilings={7: 20.0})
     assert channels(xap.max_writes) == [7]
     assert channels(xap.gain_writes) == [7]
 
 
 def test_a_refused_channel_does_not_abort_the_rest(component):
-    xap = apply(component, {7: 2.0, 8: 2.0},
-                      json.dumps({"7": -7.5, "8": -7.5}), refuse=(7,))
+    xap = apply(component, {7: 0.0, 8: 0.0}, json.dumps({"7": -7.5, "8": -7.5}),
+                ceilings={7: 20.0, 8: 20.0}, refuse=(7,))
     assert channels(xap.gain_writes) == [8]
+
+
+def test_an_offline_unit_is_left_alone(component):
+    """Every channel would otherwise raise and log a full traceback."""
+    xap = FakeXap({7: 0.0})
+    xap.connectionLive = False
+    asyncio.run(component._apply_max_gain(FakeHass(), xap, json.dumps({"7": -7.5})))
+    assert xap.max_writes == [] and xap.gain_writes == [] and xap.reads == []
 
 
 @pytest.mark.parametrize("config", ["", "   ", None, "{not json", '["not", "a", "map"]'])
 def test_nothing_is_written_without_usable_config(component, config):
-    xap = FakeXap({7: 2.0})
-    try:
-        asyncio.run(component._apply_max_gain(FakeHass(), xap, config))
-    except AttributeError:
-        pytest.fail("a non-dict config should be ignored, not crash")
-    assert xap.max_writes == []
-    assert xap.gain_writes == []
+    xap = FakeXap({7: 0.0})
+    asyncio.run(component._apply_max_gain(FakeHass(), xap, config))
+    assert xap.max_writes == [] and xap.gain_writes == []
+
+
+def test_a_gain_above_an_unchanged_ceiling_is_reported_as_an_error(component, caplog):
+    """Nothing in the integration can produce this; something else moved the gain."""
+    apply(component, {7: -5.0}, json.dumps({"7": -7.5}), ceilings={7: -7.5})
+    assert any(r.levelname == "ERROR" and "outside this integration" in r.message
+               for r in caplog.records), [r.message for r in caplog.records]
+
+
+def test_a_gain_above_a_ceiling_we_just_lowered_is_only_a_warning(component, caplog):
+    """The expected consequence of lowering a ceiling, not a fault."""
+    apply(component, {7: -5.0}, json.dumps({"7": -7.5}), ceilings={7: 0.0})
+    levels = {r.levelname for r in caplog.records}
+    assert "ERROR" not in levels
+    assert "WARNING" in levels
 
 
 # --- config-flow validation of the max_gain keys ------------------------------------

--- a/tests/test_max_gain.py
+++ b/tests/test_max_gain.py
@@ -18,6 +18,8 @@ class FakeHass:
 class FakeXap:
     """props maps channel -> proportional gain reported after its ceiling is written."""
 
+    connectionLive = True
+
     def __init__(self, props=None, refuse=()):
         self.props = props or {}
         self.refuse = set(refuse)
@@ -27,14 +29,14 @@ class FakeXap:
     def setMaxGain(self, channel, gain, group="I", unitCode=0, stereo=1):
         if channel in self.refuse:
             raise RuntimeError(f"channel {channel} refused")
-        self.max_writes.append((channel, gain, group, stereo))
+        self.max_writes.append((channel, gain, group, stereo, unitCode))
         return gain
 
     def getPropGain(self, channel, group="I", unitCode=0, stereo=1):
         return self.props[channel]
 
     def setPropGain(self, channel, gain, isAbsolute=1, group="I", unitCode=0, stereo=1):
-        self.gain_writes.append((channel, gain, group, stereo))
+        self.gain_writes.append((channel, gain, group, stereo, unitCode))
         return 1.0
 
 
@@ -50,7 +52,37 @@ def channels(writes):
 
 def test_writes_every_configured_ceiling(component):
     xap = apply(component, {7: 1.0, 8: 1.0}, json.dumps({"7": -7.5, "8": -10}))
-    assert xap.max_writes == [(7, -7.5, "O", 0), (8, -10.0, "O", 0)]
+    assert xap.max_writes == [(7, -7.5, "O", 0, 0), (8, -10.0, "O", 0, 0)]
+
+
+def test_a_bare_key_means_unit_0(component):
+    xap = apply(component, {7: 1.0}, json.dumps({"7": -7.5}))
+    assert xap.max_writes[0][4] == 0
+
+
+def test_a_unit_qualified_key_addresses_that_unit(component):
+    """A chained system: without this only the master ever gets a ceiling."""
+    xap = apply(component, {1: 1.0}, json.dumps({"1:1": -12.5}))
+    assert xap.max_writes == [(1, -12.5, "O", 0, 1)]
+
+
+def test_the_clamp_addresses_the_same_unit_as_the_ceiling(component):
+    xap = apply(component, {1: 2.0}, json.dumps({"2:1": -12.5}))
+    assert xap.max_writes[0][4] == 2
+    assert xap.gain_writes[0][4] == 2
+
+
+def test_units_are_kept_apart(component):
+    xap = apply(component, {3: 1.0}, json.dumps({"3": -7.5, "1:3": -12.0}))
+    assert [(w[0], w[4]) for w in xap.max_writes] == [(3, 0), (3, 1)]
+
+
+def test_an_offline_unit_is_left_alone(component):
+    """Every channel would otherwise raise and log a full traceback."""
+    xap = FakeXap({7: 2.0})
+    xap.connectionLive = False
+    asyncio.run(component._apply_max_gain(FakeHass(), xap, json.dumps({"7": -7.5})))
+    assert xap.max_writes == [] and xap.gain_writes == []
 
 
 def test_ceilings_are_written_per_channel_not_per_stereo_pair(component):
@@ -116,3 +148,57 @@ def test_nothing_is_written_without_usable_config(component, config):
         pytest.fail("a non-dict config should be ignored, not crash")
     assert xap.max_writes == []
     assert xap.gain_writes == []
+
+
+# --- config-flow validation of the max_gain keys ------------------------------------
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        '{"7": -15}',
+        '{"7": -15, "8": -10.5}',
+        '{"1:1": -12}',
+        '{"7": -15, "1:1": -12}',
+        '{"0:7": -15}',
+        '{"1": 20}',
+        '{"1": -65}',
+        "",
+        "   ",
+    ],
+)
+def test_valid_max_gain_is_accepted(config_flow, raw):
+    config_flow._validate_max_gain(raw)
+
+
+@pytest.mark.parametrize(
+    "raw,why",
+    [
+        ('{"7": -66}', "below the -65 dB floor"),
+        ('{"7": 21}', "above the +20 dB maximum"),
+        ('{"0": -15}', "channel numbers start at 1"),
+        ('{"8:1": -15}', "unit codes stop at 7"),
+        ('{"1:0": -15}', "channel numbers start at 1"),
+        ('{"1:2:3": -15}', "not a unit:channel pair"),
+        ('{"kitchen": -15}', "not a channel at all"),
+        ('{"7": -15, "0:7": -12}', "same channel twice"),
+        ('{"7": true}', "a bool is not a dB value"),
+        ('{"7": "-15"}', "a string is not a dB value"),
+        ('["7", -15]', "must be an object"),
+        ("{not json", "must be JSON"),
+    ],
+)
+def test_invalid_max_gain_is_rejected(config_flow, raw, why):
+    with pytest.raises(Exception):
+        config_flow._validate_max_gain(raw)
+
+
+@pytest.mark.parametrize(
+    "key,expected", [("7", (0, 7)), ("0:7", (0, 7)), ("1:1", (1, 1)), (7, (0, 7))]
+)
+def test_parse_channel_key(config_flow, key, expected):
+    assert config_flow.parse_channel_key(key) == expected
+
+
+def test_max_gain_bounds_match_the_documented_hardware_range(config_flow):
+    """MAX takes a Signed Float of -65.00 - 20.00 dB on XAP and Converge alike."""
+    assert (config_flow.MAX_GAIN_MIN_DB, config_flow.MAX_GAIN_MAX_DB) == (-65.0, 20.0)

--- a/translations/en.json
+++ b/translations/en.json
@@ -30,17 +30,19 @@
       },
       "sources_zones": {
         "title": "XAP Controller — Sources & Zones",
-        "description": "Enter sources and zones as JSON objects. Keys are names, values are lists of channel specs (integers or strings like \"1:3\" or \"1:9:O:E\").",
+        "description": "Enter sources and zones as JSON objects. Keys are names, values are lists of channel specs (integers or strings like \"1:3\" or \"1:9:O:E\"). Max gain is optional: a JSON object mapping output channel to a dB ceiling, e.g. {\"7\": -15}. It caps how loud that output can ever be driven and sets what 100% volume means. Leave blank to leave the unit's own setting alone.",
         "data": {
           "sources": "Sources (JSON)",
-          "zones": "Zones (JSON)"
+          "zones": "Zones (JSON)",
+          "max_gain": "Max gain per output channel (JSON, optional)"
         }
       }
     },
     "error": {
       "cannot_connect": "Unable to connect to the XAP unit. Check your connection settings. You may still proceed if the connection is intermittent.",
       "invalid_sources": "Invalid sources JSON. Expected an object mapping names to lists of channel specs.",
-      "invalid_zones": "Invalid zones JSON. Expected an object mapping names to lists of channel specs."
+      "invalid_zones": "Invalid zones JSON. Expected an object mapping names to lists of channel specs.",
+      "invalid_max_gain": "Invalid max gain JSON. Expected an object mapping output channel numbers to a dB value between -65 and 20, e.g. {\"7\": -15, \"8\": -15}."
     },
     "abort": {
       "already_configured": "This XAP unit is already configured."
@@ -77,17 +79,19 @@
       },
       "sources_zones": {
         "title": "XAP Controller — Sources & Zones",
-        "description": "Enter sources and zones as JSON objects. Keys are names, values are lists of channel specs (integers or strings like \"1:3\" or \"1:9:O:E\").",
+        "description": "Enter sources and zones as JSON objects. Keys are names, values are lists of channel specs (integers or strings like \"1:3\" or \"1:9:O:E\"). Max gain is optional: a JSON object mapping output channel to a dB ceiling, e.g. {\"7\": -15}. It caps how loud that output can ever be driven and sets what 100% volume means. Leave blank to leave the unit's own setting alone.",
         "data": {
           "sources": "Sources (JSON)",
-          "zones": "Zones (JSON)"
+          "zones": "Zones (JSON)",
+          "max_gain": "Max gain per output channel (JSON, optional)"
         }
       }
     },
     "error": {
       "cannot_connect": "Unable to connect to the XAP unit.",
       "invalid_sources": "Invalid sources JSON. Expected an object mapping names to lists of channel specs.",
-      "invalid_zones": "Invalid zones JSON. Expected an object mapping names to lists of channel specs."
+      "invalid_zones": "Invalid zones JSON. Expected an object mapping names to lists of channel specs.",
+      "invalid_max_gain": "Invalid max gain JSON. Expected an object mapping output channel numbers to a dB value between -65 and 20, e.g. {\"7\": -15, \"8\": -15}."
     }
   }
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -30,7 +30,7 @@
       },
       "sources_zones": {
         "title": "XAP Controller — Sources & Zones",
-        "description": "Enter sources and zones as JSON objects. Keys are names, values are lists of channel specs (integers or strings like \"1:3\" or \"1:9:O:E\"). Max gain is optional: a JSON object mapping output channel to a dB ceiling, e.g. {\"7\": -15}. It caps how loud that output can ever be driven and sets what 100% volume means. Leave blank to leave the unit's own setting alone.",
+        "description": "Enter sources and zones as JSON objects. Keys are names, values are lists of channel specs (integers or strings like \"1:3\" or \"1:9:O:E\"). Max gain is optional: a JSON object mapping output channel to a dB ceiling, e.g. {\"7\": -15, \"1:1\": -12}. A key is a bare channel on unit 0, or \"unit:channel\" for a chained system. It caps how loud that output can ever be driven and sets what 100% volume means. Leave blank to leave the unit's own setting alone.",
         "data": {
           "sources": "Sources (JSON)",
           "zones": "Zones (JSON)",
@@ -42,7 +42,7 @@
       "cannot_connect": "Unable to connect to the XAP unit. Check your connection settings. You may still proceed if the connection is intermittent.",
       "invalid_sources": "Invalid sources JSON. Expected an object mapping names to lists of channel specs.",
       "invalid_zones": "Invalid zones JSON. Expected an object mapping names to lists of channel specs.",
-      "invalid_max_gain": "Invalid max gain JSON. Expected an object mapping output channel numbers to a dB value between -65 and 20, e.g. {\"7\": -15, \"8\": -15}."
+      "invalid_max_gain": "Invalid max gain JSON. Expected an object mapping output channels to a dB value between -65 and 20, e.g. {\"7\": -15, \"1:1\": -12}. Keys are a bare channel or \"unit:channel\"."
     },
     "abort": {
       "already_configured": "This XAP unit is already configured."
@@ -79,7 +79,7 @@
       },
       "sources_zones": {
         "title": "XAP Controller — Sources & Zones",
-        "description": "Enter sources and zones as JSON objects. Keys are names, values are lists of channel specs (integers or strings like \"1:3\" or \"1:9:O:E\"). Max gain is optional: a JSON object mapping output channel to a dB ceiling, e.g. {\"7\": -15}. It caps how loud that output can ever be driven and sets what 100% volume means. Leave blank to leave the unit's own setting alone.",
+        "description": "Enter sources and zones as JSON objects. Keys are names, values are lists of channel specs (integers or strings like \"1:3\" or \"1:9:O:E\"). Max gain is optional: a JSON object mapping output channel to a dB ceiling, e.g. {\"7\": -15, \"1:1\": -12}. A key is a bare channel on unit 0, or \"unit:channel\" for a chained system. It caps how loud that output can ever be driven and sets what 100% volume means. Leave blank to leave the unit's own setting alone.",
         "data": {
           "sources": "Sources (JSON)",
           "zones": "Zones (JSON)",
@@ -91,7 +91,7 @@
       "cannot_connect": "Unable to connect to the XAP unit.",
       "invalid_sources": "Invalid sources JSON. Expected an object mapping names to lists of channel specs.",
       "invalid_zones": "Invalid zones JSON. Expected an object mapping names to lists of channel specs.",
-      "invalid_max_gain": "Invalid max gain JSON. Expected an object mapping output channel numbers to a dB value between -65 and 20, e.g. {\"7\": -15, \"8\": -15}."
+      "invalid_max_gain": "Invalid max gain JSON. Expected an object mapping output channels to a dB value between -65 and 20, e.g. {\"7\": -15, \"1:1\": -12}. Keys are a bare channel or \"unit:channel\"."
     }
   }
 }


### PR DESCRIPTION
> Stacks on #18 — it adds `tests/test_max_gain.py`, which uses the `conftest.py` from that PR. The component change is independent; only the test file needs #18 first.

### The problem

`MAXGAIN` is a per-channel ceiling in the XAP hardware, and it's *also* the reference `volume_level` is measured against — `getPropGain`/`setPropGain` express level as a ratio of it, so `volume_level: 1.0` means "this channel's MAXGAIN".

An unconfigured unit leaves MAXGAIN at the **+20 dB factory maximum**, which is bad twice over:

- **Safety.** A slider dragged to 100% drives the output at +20 dB. On ceiling speakers that is not a volume anyone intended.
- **Usability.** Real listening levels are far below that, so they crowd into the bottom of the slider. On my unit, four zones sitting between −22.5 and −33 dB all landed under **1%** — the entire useful range inside a couple of pixels of travel.

### What this adds

An optional **Max gain** field on the Sources & Zones step, a JSON object mapping output channel to a dB ceiling, validated to the hardware's −65…+20 dB range. Blank keeps today's behaviour and writes nothing. Ceilings are re-applied on every setup, so a change made in G-Ware or from the front panel is restored on the next start.

### And a clamp, which is the part I'd read closely

**Lowering MAXGAIN does not move a GAIN that is already above it.** The XAP leaves the level exactly where it was, sitting above its own stated maximum.

That is not theoretical. On my unit a reload wrote all eight ceilings to −15.00 underneath outputs running between −7.50 and −13.34. Since `volume_level` is a ratio against MAXGAIN, every zone then reported a value **greater than 1.0** — one came back `2.371`, a slider at 237% — Home Assistant had no valid range to render, and any slider move wrote dB against a ceiling those levels were never chosen for. It took a direct `GAIN`/`MAX` read off the unit to see it, because nothing in the integration could.

So since we rewrite the ceilings on every setup anyway, the level comes with them. `volume_level <= 1.0` becomes true by construction for every configured channel. **The clamp only ever reduces a level, never raises one**, and channels absent from the config are untouched.

It's expressed in proportional gain because that's already the ratio to MAXGAIN — above 1.0 is above the ceiling, writing 1.0 lands exactly on it — and compared in dB against a small tolerance rather than a bare `> 1.0`:

```python
over_db = 20.0 * math.log10(prop) if prop > 0 else 0.0
if over_db > GAIN_CLAMP_TOLERANCE_DB:
```

That tolerance matters. `db2linear` adds a 1e-7 dB offset in `XAPX00` 2026.04.22, so a channel sitting *exactly* on its ceiling returns `1.0000000115`, not `1.0` — a bare `> 1.0` clamps it and logs a "0.00 dB above" warning on **every single startup**. (2026.09.03 subtracts a linear epsilon instead and returns `0.999999`; the tests are parametrised over both, so neither can be misread as an overshoot.)

### Testing

15 tests covering the ceiling writes, the clamp, the tolerance from both XAPX00 builds, and the error-isolation paths. Running on an XAP800 with eight configured ceilings; a restart is a verified no-op when nothing is above its ceiling.

---

Part of a series from my fork ([defl/xap_controller](https://github.com/defl/xap_controller)). The biggest of them — happy to split the clamp out from the ceiling feature if you'd rather take them separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)