### PR TITLE
Deprecate the stereo option

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,24 @@ There are two components in the platform: output Zones and input Sources.  The i
 
 The system can have multple units linked together.  The configured Sources and Zones can specify only the channel for input or output, in which case it is assumed they are on unit 0.  They can also specify the unit, and optionally, for sources, an expansion bus that the source is also mapped to, so that it can be used on other units in the systems.  In this case, list the unit:channel of the source, and then the expansion channel and optinoally expansion group (E or P).  When sources or zones are specified with units and expansion buses, the items should be listed as a string of the format "<Unit#>:<Channel#>:<Expansion Bus Channel Letter>:<Expansion BUs Group>".  See below for an example.  For the expansion bus setup to work the matrix needs to have the sources mapped to the expansin channels through the G-Ware software.
 
-The system can assume that the channels are set up for stereo, so that there are 2 channels paired 
-together.  If stereo=1, the module will take each action twice, once on the listed source/zone number and again on the source/zone + 1.  This functionality may be removed in the future to promote clarity, so if ia stereo setup is used, it is recommneded to list each channel explicitly.
+**The `stereo` option is deprecated and will be removed in a future release.**  If stereo=1, the module takes each action twice, once on the listed source/zone number and again on the source/zone + 1.  It overlaps the explicit multi-channel list below, and the two are unsafe in combination: a zone listed as `[3, 4]` with `stereo: 1` writes crosspoints for 3&4 and then 4&5, and channel 5 belongs to some other zone.  List each channel explicitly instead:
+
+```yaml
+# deprecated
+stereo: 1
+zones:
+  'Office':
+    - 3
+
+# preferred
+stereo: 0
+zones:
+  'Office':
+    - 3
+    - 4
+```
+
+See [issue #23](https://github.com/jslove/xap_controller/issues/23) for the removal plan.
 
 For each source or zone, multiple channels can be listed, as a list.  If multiple channels are listed for a source and an output, they will be paired sequentially, source item 1 to zone item 1, source item 2 to zone item 2, etc.  If there are more source channels than zone channels, only the first channels in the source will be used.  If there are more channels in a zone than in the source being applied ot it, the source channels will be repeated.  This multiple channel apporach can be used to handle stereo (instead of the stereo=1 approach), but it was added to handle surround sound sources / zones. The XAP system will mix multiple source channels applied to one output zone channel.
 
@@ -91,7 +107,7 @@ media_player:
    sources are listed as either a digit, indicating the input channel on unit 0, or else a string of the format:  "<unit#>:<input#>:<bus letter>:<bus type>. Bus and Bus type are optional, but are needed if using more than 1 unit and you want a source to be available on outputs in other units.
 * path: serial device path (can be a virtual serial port, using socat for example)
 * name: the name of the platform instance
-* stereo: 1=stereo, 0=mono  If stereo=1, each action will be performed twice on the input (output) and input+1 (output)+1
+* stereo: **deprecated** — 1=stereo, 0=mono.  If stereo=1, each action will be performed twice on the input (output) and input+1 (output)+1.  List channels explicitly instead; see above.
 * baud: baud rate of serial port, 38400 (default), 9600, 19200, 57600
 * XAPType: XAP unit type, eithr XAP800 (default) or XAP400
 

--- a/media_player.py
+++ b/media_player.py
@@ -203,6 +203,15 @@ async def async_setup_entry(hass, entry, async_add_entities):
     conn_type = entry.data.get(CONF_CONNECTION_TYPE, "serial")
     xap_type  = entry.data.get(CONF_TYPE, "XAP800")
     stereo    = 1 if entry.data.get(CONF_STEREO, False) else 0
+    if stereo:
+        # Deprecated: overlaps the explicit multi-channel list and is unsafe combined
+        # with it -- a zone listed as [3, 4] with stereo on writes crosspoints 3&4 and
+        # then 4&5. See https://github.com/jslove/xap_controller/issues/23
+        _LOGGER.warning(
+            "The 'stereo' option is deprecated and will be removed in a future release. "
+            "List each channel explicitly instead: a zone of [3] with stereo on becomes "
+            "a zone of [3, 4] with stereo off. See issue #23."
+        )
 
     # XAPX00.__init__ calls test_connection() internally, which uses
     # loop.run_until_complete() for telnet.  That must not run on HA's event

--- a/strings.json
+++ b/strings.json
@@ -6,7 +6,7 @@
         "data": {
           "name": "Name",
           "XAPType": "Device type",
-          "stereo": "Stereo mode",
+          "stereo": "Stereo mode (deprecated)",
           "connection_type": "Connection type"
         }
       },
@@ -53,7 +53,7 @@
         "data": {
           "name": "Name",
           "XAPType": "Device type",
-          "stereo": "Stereo mode",
+          "stereo": "Stereo mode (deprecated)",
           "connection_type": "Connection type"
         }
       },

--- a/translations/en.json
+++ b/translations/en.json
@@ -6,7 +6,7 @@
         "data": {
           "name": "Name",
           "XAPType": "Device type",
-          "stereo": "Stereo mode",
+          "stereo": "Stereo mode (deprecated)",
           "connection_type": "Connection type"
         }
       },
@@ -53,7 +53,7 @@
         "data": {
           "name": "Name",
           "XAPType": "Device type",
-          "stereo": "Stereo mode",
+          "stereo": "Stereo mode (deprecated)",
           "connection_type": "Connection type"
         }
       },


### PR DESCRIPTION
Step 1 of the plan in #23: warn, document, and keep honouring the option for one release.

- `media_player.py` logs a warning at setup when `stereo` is set, naming the explicit-channel-list replacement
- README replaces "may be removed in the future" with a definite deprecation, explains why the two mechanisms are unsafe together, and gives a before/after migration
- The config-flow field is labelled "Stereo mode (deprecated)" in `strings.json` and `translations/en.json`

**No behaviour change** — the option is still honoured, so existing installs keep working and get a release in which to convert. Removal (dropping the two `conn.stereo` assignments and the config-flow field) follows in a later release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)