### PR TITLE
Set every zone output from the requested level, not the last read-back

### DIFF
--- a/media_player.py
+++ b/media_player.py
@@ -910,14 +910,27 @@ class XAPZone(MediaPlayerEntity):
         """Blocking XAP call — run in executor."""
         if not self.connectionLive(): return
         _LOGGER.debug("set_volume_level: {}:{}".format(self, volume))
-        for output in self._outputs:
+        # `volume` is never reassigned in this loop. setPropGain returns the achieved
+        # proportion for the channel it just wrote, relative to THAT channel's MAXGAIN,
+        # so feeding it forward would set every output after the first from the previous
+        # channel's read-back instead of from what the caller asked for. Harmless while
+        # every channel shares one MAXGAIN and nothing clamps -- the round trip is a
+        # fixed point -- and wrong as soon as either stops being true.
+        reported = volume
+        for index, output in enumerate(self._outputs):
             XUNIT, XOUT = self.parse_output(output)
             _LOGGER.debug("Set Volume for output {} to {}".format(output, volume))
-            volume = await self._xap(
-                lambda XOUT=XOUT, XUNIT=XUNIT:
-                    self._xapx00.setPropGain(XOUT, volume, group="O", unitCode=XUNIT)
+            landed = await self._xap(
+                lambda XOUT=XOUT, XUNIT=XUNIT, v=volume:
+                    self._xapx00.setPropGain(XOUT, v, group="O", unitCode=XUNIT)
             )
-        self._volume = volume
+            if index == 0:
+                # Agree with _get_volume_level, which reads _outputs[0]. On a zone whose
+                # channels have different ceilings there is no single honest answer, so
+                # the getter and the setter reporting the same channel is the least
+                # surprising of the available wrong answers.
+                reported = landed
+        self._volume = reported
 
     @handle_xap_exceptions
     async def _get_volume_level(self):

--- a/tests/test_zone_volume.py
+++ b/tests/test_zone_volume.py
@@ -1,0 +1,100 @@
+"""XAPZone.async_set_volume_level: every output is set from the requested level.
+
+setPropGain returns the achieved proportion relative to the channel it wrote, so a loop
+that feeds its return value forward sets each output after the first from the previous
+channel's read-back. These tests only bite when the read-back differs from the request --
+with a faithful device and one shared MAXGAIN the round trip is a fixed point and the
+buggy code produces identical calls. So the fake below clamps per channel, which is
+exactly the condition per-channel ceilings introduce.
+"""
+
+import asyncio
+
+import pytest
+
+
+class FakeHass:
+    async def async_add_executor_job(self, fn):
+        return fn()
+
+
+class FakeConn:
+    """setPropGain that clamps to a per-channel ceiling, as a unit with per-channel
+    MAXGAIN does: the value that lands is not the value requested."""
+
+    def __init__(self, ceilings=None, live=True):
+        self.conn_id = "fake"
+        self.connectionLive = 1 if live else 0
+        self.ceilings = ceilings or {}
+        self.calls = []
+
+        class _Lock:
+            def __enter__(self_inner):
+                return None
+
+            def __exit__(self_inner, *a):
+                return False
+
+        self._lock = _Lock()
+
+    def setPropGain(self, channel, gain, isAbsolute=1, group="I", unitCode=0):
+        self.calls.append((unitCode, channel, gain))
+        return min(gain, self.ceilings.get((unitCode, channel), 1.0))
+
+
+def zone(component, conn, outputs, name="Kitchen"):
+    return component.XAPZone(FakeHass(), conn, {}, name, outputs)
+
+
+def test_every_output_is_set_from_the_requested_level(component):
+    # Output 1 clamps to 0.5; output 2 must still be asked for 0.8, not for 0.5.
+    conn = FakeConn(ceilings={(0, 1): 0.5})
+    z = zone(component, conn, [1, 2])
+    asyncio.run(z.async_set_volume_level(0.8))
+    assert conn.calls == [(0, 1, 0.8), (0, 2, 0.8)]
+
+
+def test_a_clamp_does_not_propagate_down_a_six_channel_zone(component):
+    conn = FakeConn(ceilings={(1, 9): 0.25})
+    z = zone(component, conn, ["1:9", "1:10", "1:11", "1:12"], name="Family Surround")
+    asyncio.run(z.async_set_volume_level(0.9))
+    assert [g for _u, _c, g in conn.calls] == [0.9, 0.9, 0.9, 0.9]
+
+
+def test_the_reported_level_follows_the_first_output(component):
+    # _get_volume_level reads _outputs[0]; the setter must agree with it.
+    conn = FakeConn(ceilings={(0, 1): 0.5, (0, 2): 0.9})
+    z = zone(component, conn, [1, 2])
+    asyncio.run(z.async_set_volume_level(0.8))
+    assert z._volume == 0.5
+
+
+def test_an_unclamped_zone_reports_what_was_asked_for(component):
+    conn = FakeConn()
+    z = zone(component, conn, [3, 4])
+    asyncio.run(z.async_set_volume_level(0.1))
+    assert z._volume == 0.1
+    assert conn.calls == [(0, 3, 0.1), (0, 4, 0.1)]
+
+
+def test_channels_repeated_in_a_zone_are_each_written(component):
+    # Kitchen is [3, 4, 3, 4] on the rig this was written against: the repeats are
+    # deliberate and must not be collapsed the way the cache pre-warm collapses reads.
+    conn = FakeConn()
+    z = zone(component, conn, [3, 4, 3, 4])
+    asyncio.run(z.async_set_volume_level(0.2))
+    assert conn.calls == [(0, 3, 0.2), (0, 4, 0.2), (0, 3, 0.2), (0, 4, 0.2)]
+
+
+def test_outputs_on_a_chained_unit_keep_their_unit(component):
+    conn = FakeConn()
+    z = zone(component, conn, [7, "1:7"])
+    asyncio.run(z.async_set_volume_level(0.3))
+    assert conn.calls == [(0, 7, 0.3), (1, 7, 0.3)]
+
+
+def test_an_offline_zone_writes_nothing(component):
+    conn = FakeConn(live=False)
+    z = zone(component, conn, [1, 2])
+    asyncio.run(z.async_set_volume_level(0.8))
+    assert conn.calls == []


### PR DESCRIPTION
The zone twin of the source-loop bug fixed in #22, and the one that matters for #21.

### The bug

`XAPZone.async_set_volume_level` reassigns its loop variable from the return of `setPropGain`:

```python
for output in self._outputs:
    XUNIT, XOUT = self.parse_output(output)
    volume = await self._xap(                     # <-- rebinds `volume`
        lambda XOUT=XOUT, XUNIT=XUNIT:
            self._xapx00.setPropGain(XOUT, volume, group="O", unitCode=XUNIT))
```

`setPropGain` returns the achieved proportion for the channel it just wrote, relative to **that channel's** MAXGAIN. So every output after the first is set from the previous channel's round-tripped value rather than from what the caller asked for.

### Why it is harmless today, and why that is about to change

With one shared MAXGAIN across a zone and nothing clamping, `linear2db` → 4dp formatting → `db2linear` is a fixed point, so the value fed forward *is* the value requested. That was measured previously at ≤0.005 dB of drift over six channels, and zero with device gain quantisation.

Both premises hold only while MAXGAIN is uniform. #21 makes per-channel ceilings a user-editable field and adds a clamp — which is the other trigger condition, a device write whose result differs from the request. So this goes from documented-and-harmless to live, on the path that runs on every volume change.

### It is worst where it is least visible

With output `1:9` clamping to 0.25, a four-channel zone asked for 0.9 is written:

```
0.9, 0.25, 0.25, 0.25
```

One clamped channel drags the rest of the zone down with it, silently. Nothing logs, nothing reports a mismatch, and the zone is simply quiet on three of its four outputs. Multi-channel zones — the ones most likely to have mixed ceilings — are exactly the ones that lose the most.

### The fix

Every output is set from the requested level. The reported level is the **first** output's read-back, which agrees with `_get_volume_level` — that also reads `_outputs[0]`. On a zone whose channels have different ceilings there is no single honest answer, so matching the getter seemed the least surprising of the available wrong ones.

### Deliberately out of scope

The call still does not pass `stereo=0`. Adding it would change behaviour for anyone relying on the deprecated `stereo` option to write the second channel of a pair — a zone of `[3]` with stereo on. That belongs with removing the option (#23), not with this fix.

### Testing

7 tests. **Two fail against the code this replaces**; the other five are regression guards that pass either way.

The fixture matters here, as it did in #22: with a faithful device and one shared MAXGAIN the read-back equals the request and the buggy code produces identical calls, so the test passes against both. The fake clamps per channel instead — the condition per-channel ceilings introduce — which is what makes the difference observable.

47 pass on the branch. Not verified against hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
