### PR TITLE
Close out the review follow-ups from #15 and #18

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,22 @@
+name: tests
+
+on:
+  push:
+    branches: [master, next]
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # Home Assistant's own supported range; the suite stubs HA rather than
+        # installing it, so this is really "does the component still import and parse".
+        python-version: ["3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install pytest
+      - run: python -m pytest tests -q

--- a/config_flow.py
+++ b/config_flow.py
@@ -33,6 +33,45 @@ SOURCES_EXAMPLE = '{"Home Audio": [9], "TV": ["1:11:O:E"]}'
 ZONES_EXAMPLE = '{"Kitchen": [3], "Office": ["2:1", "2:2"]}'
 
 
+# How many colon-separated components a channel spec may carry. A zone output is
+# "<unit>:<channel>"; a source may also name an expansion bus and its group,
+# "<unit>:<channel>:<bus>:<busgroup>".
+_MAX_SPEC_PARTS = {"zones": 2, "sources": 4}
+
+
+def _validate_channel_spec(spec, label: str) -> None:
+    """Reject a channel spec the parsers cannot make sense of.
+
+    Checking only the item type let malformed specs through to setup, where they surfaced
+    as a crash rather than as a config error: "1:2:3" reached parse_output and raised
+    ValueError unpacking three parts into two, and "1:2:3:4:5" reached parse_source,
+    matched none of its comps branches, and hit int(None).
+
+    Deliberately loose about the expansion-bus fields - only the component count and the
+    numeric parts are checked - so that a working configuration using a bus letter or
+    group this does not know about is not locked out at the config screen.
+    """
+    if isinstance(spec, bool) or not isinstance(spec, (int, str)):
+        raise vol.Invalid(f"invalid_{label}")
+    if isinstance(spec, int):
+        return
+    text = spec.strip()
+    if not text:
+        raise vol.Invalid(f"invalid_{label}")
+    parts = text.split(":")
+    if len(parts) > _MAX_SPEC_PARTS.get(label, 4):
+        raise vol.Invalid(f"invalid_{label}")
+    if len(parts) == 1:
+        if not text.isdigit():
+            raise vol.Invalid(f"invalid_{label}")
+        return
+    unit, channel = parts[0].strip(), parts[1].strip()
+    if not unit.isdigit() or not channel.isdigit():
+        raise vol.Invalid(f"invalid_{label}")
+    if any(not part.strip() for part in parts[2:]):
+        raise vol.Invalid(f"invalid_{label}")
+
+
 def _validate_sources_zones(json_str: str, label: str) -> dict:
     """Parse and validate a JSON sources/zones string. Returns the parsed dict."""
     try:
@@ -47,8 +86,7 @@ def _validate_sources_zones(json_str: str, label: str) -> dict:
         if not isinstance(val, list):
             raise vol.Invalid(f"invalid_{label}")
         for item in val:
-            if not isinstance(item, (int, str)):
-                raise vol.Invalid(f"invalid_{label}")
+            _validate_channel_spec(item, label)
     return data
 
 
@@ -311,6 +349,7 @@ class XapControllerOptionsFlow(config_entries.OptionsFlow):
                 if not connected:
                     errors["base"] = "cannot_connect"
             except Exception:
+                _LOGGER.exception("XAP connection test failed")
                 errors["base"] = "cannot_connect"
 
             if not errors:

--- a/media_player.py
+++ b/media_player.py
@@ -561,12 +561,19 @@ class XAPSource(MediaPlayerEntity):
                     if comps == 1:
                         inpdict['UNIT'], inpdict['CHAN']  =  src.split(":")
                     elif comps == 2:
+                        # BUSGRP already defaults to 'E' in inpdict above.
                         inpdict['UNIT'], inpdict['CHAN'], inpdict['BUS'] = src.split(":")
-                        XBUSGRP = 'E' # default to E
                     elif comps == 3:
                         inpdict['UNIT'], inpdict['CHAN'], inpdict['BUS'], inpdict['BUSGRP'] = src.split(":")
-                    inpdict['CHAN'] = int(inpdict['CHAN'])
-                    inpdict['UNIT'] = int(inpdict['UNIT'])
+                    else:
+                        # Anything longer used to match no branch at all, leaving CHAN as
+                        # None until int(None) raised TypeError further down.
+                        raise Exception('Invalid Input String')
+                    try:
+                        inpdict['CHAN'] = int(inpdict['CHAN'])
+                        inpdict['UNIT'] = int(inpdict['UNIT'])
+                    except (TypeError, ValueError):
+                        raise Exception('Invalid Input String')
                 elif src.isdigit():
                     inpdict['CHAN'] = int(src)
                 else:
@@ -772,7 +779,12 @@ class XAPZone(MediaPlayerEntity):
             XOUT = output
         elif issubclass(type(output), str):
             if ":" in output:
-                XUNIT, XOUT =  output.split(":")
+                # "1:2:3" used to raise ValueError unpacking three parts into two, which
+                # surfaced at setup rather than as a config error.
+                parts = output.split(":")
+                if len(parts) != 2:
+                    raise Exception('Invalid Output String')
+                XUNIT, XOUT = parts
             elif output.isdigit():
                 # Unit 0, same as the bare int form. Without this XUNIT is never bound
                 # and the return below raises UnboundLocalError - and a bare numeric
@@ -785,7 +797,11 @@ class XAPZone(MediaPlayerEntity):
         else:
             # shouldn't be able to get here
             raise Exception('Invalid Output config format')
-        return int(XUNIT), int(XOUT)
+        try:
+            return int(XUNIT), int(XOUT)
+        except (TypeError, ValueError):
+            # e.g. "a:2" - reaches here with the parts split but not numeric
+            raise Exception('Invalid Output String')
 
     async def async_update(self):
         pass  # can't be changed except by us, so can track state without calls

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -85,3 +85,69 @@ def test_valid_sources_zones_accepted(config_flow, raw):
 def test_invalid_sources_zones_rejected(config_flow, raw):
     with pytest.raises(Exception):
         config_flow._validate_sources_zones(raw, "zones")
+
+
+# --- malformed specs: caught at config time, and survivable at parse time -----------
+
+@pytest.mark.parametrize(
+    "spec,why",
+    [
+        ("1:2:3", "a zone output is unit:channel, nothing longer"),
+        ("1:2:3:4:5", "longer than any documented form"),
+        ("a:2", "unit is not a number"),
+        ("1:b", "channel is not a number"),
+        ("kitchen", "not a channel at all"),
+        ("", "empty"),
+        ("   ", "blank"),
+        (1.5, "not an int or a string"),
+        (True, "a bool is not a channel"),
+    ],
+)
+def test_malformed_zone_specs_are_rejected_at_config_time(config_flow, spec, why):
+    with pytest.raises(Exception):
+        config_flow._validate_channel_spec(spec, "zones")
+
+
+@pytest.mark.parametrize("spec", [3, "3", "1:3"])
+def test_valid_zone_specs_are_accepted(config_flow, spec):
+    config_flow._validate_channel_spec(spec, "zones")
+
+
+@pytest.mark.parametrize("spec", [9, "9", "1:9", "1:9:O", "1:9:O:E"])
+def test_valid_source_specs_are_accepted(config_flow, spec):
+    """A source may name an expansion bus and its group; a zone output may not."""
+    config_flow._validate_channel_spec(spec, "sources")
+
+
+def test_a_source_bus_spec_is_not_valid_for_a_zone(config_flow):
+    config_flow._validate_channel_spec("1:9:O:E", "sources")
+    with pytest.raises(Exception):
+        config_flow._validate_channel_spec("1:9:O:E", "zones")
+
+
+@pytest.mark.parametrize("spec", ["1:2:3:4:5", "1:9::E"])
+def test_malformed_source_specs_are_rejected_at_config_time(config_flow, spec):
+    with pytest.raises(Exception):
+        config_flow._validate_channel_spec(spec, "sources")
+
+
+def test_the_validator_rejects_a_bad_spec_inside_a_zone_list(config_flow):
+    with pytest.raises(Exception):
+        config_flow._validate_sources_zones('{"Kitchen": [3, "1:2:3"]}', "zones")
+
+
+@pytest.mark.parametrize("spec", ["1:2:3", "a:2", "1:b"])
+def test_parse_output_raises_its_own_error_on_a_bad_spec(component, spec):
+    """Not ValueError from an unpack - these reach setup if validation is bypassed."""
+    zone = make_zone(component, [1])
+    with pytest.raises(Exception) as err:
+        zone.parse_output(spec)
+    assert "Invalid Output" in str(err.value)
+
+
+@pytest.mark.parametrize("spec", ["1:2:3:4:5", "a:2", "1:b"])
+def test_parse_source_raises_its_own_error_on_a_bad_spec(component, spec):
+    """"1:2:3:4:5" matched no comps branch and died on int(None)."""
+    with pytest.raises(Exception) as err:
+        make_source(component, [spec])
+    assert "Invalid Input String" in str(err.value)


### PR DESCRIPTION
All four items from #24. Independent of #21 and #22.

Closes #24.

### 1. The third connection-test handler

`_LOGGER.exception` added at the options-flow site. As you said, that's the one an already-configured user reaches, and a swallowed traceback there is exactly what hid the `XAPX00.XAPX00` bug.

### 2. Malformed channel specs

Both now raise the existing errors rather than dying oddly:

```
parse_output("1:2:3")     Invalid Output String   (was ValueError on the unpack)
parse_source("1:2:3:4:5") Invalid Input String    (was TypeError from int(None))
```

Non-numeric unit or channel — `"a:2"`, `"1:b"` — also raise the proper error rather than a bare `ValueError` from `int()`.

**And caught at config time**, which you rightly said was better still. `_validate_sources_zones` now shape-checks string specs: component count, and that unit and channel are numeric.

I kept it **deliberately loose about the expansion-bus fields**. Only the count and the numeric parts are checked, so a working setup using a bus letter or group this validator doesn't know about isn't locked out at the config screen. A zone output allows two components, a source four — which also means `"1:9:O:E"` is valid as a source and rejected as a zone, matching what the parsers actually do with it.

### 3. Dead local

Gone. `inpdict` already defaults `BUSGRP` to `'E'`, so the comment now says that instead.

### 4. CI

`.github/workflows/tests.yml`, running on pushes to `master`/`next` and on PRs, across 3.12 and 3.13. It installs **only pytest** — the suite stubs Home Assistant rather than depending on it, so there's nothing heavier to pull.

### Testing

84 pass. The parser fixes are pinned by tests that fail against the current code:

```
FAILED test_parse_output_raises_its_own_error_on_a_bad_spec[1:2:3]
FAILED test_parse_source_raises_its_own_error_on_a_bad_spec[1:2:3:4:5]
FAILED test_parse_source_raises_its_own_error_on_a_bad_spec[a:2]
FAILED test_parse_source_raises_its_own_error_on_a_bad_spec[1:b]
```

`test_parse_output_rejects_nonsense` covered only `"kitchen"`, as you noted; the malformed-spec cases are parametrised now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)